### PR TITLE
[demo][2-3] 幸福度入力API作成

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,8 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "axios": "^1.6.7",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "uuid": "^9.0.1"
@@ -23,6 +25,7 @@
         "@nestjs/testing": "^10.0.0",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
+        "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "^20.3.1",
         "@types/supertest": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -2087,7 +2090,6 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -2097,7 +2099,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2138,7 +2139,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -2150,7 +2150,6 @@
       "version": "4.17.41",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
       "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -2170,8 +2169,7 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2213,6 +2211,14 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
+      "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -2222,14 +2228,12 @@
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/node": {
       "version": "20.11.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
       "integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2237,14 +2241,12 @@
     "node_modules/@types/qs": {
       "version": "6.9.11",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
-      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
-      "dev": true
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -2256,7 +2258,6 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -2266,7 +2267,6 @@
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
       "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
-      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -3205,6 +3205,11 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3761,7 +3766,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3919,6 +3923,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -6184,6 +6196,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
+      "integrity": "sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6268,6 +6288,62 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.1.0.tgz",
+      "integrity": "sha512-v7nqlfezb9YfHHzYII3ef2a2j1XnGeSE/bK3WfumaYCqONAIstJbrEGapz4kadScZzEt7zYCN7bucj8C0Mv/Rg==",
+      "dependencies": {
+        "@types/express": "^4.17.17",
+        "@types/jsonwebtoken": "^9.0.2",
+        "debug": "^4.3.4",
+        "jose": "^4.14.6",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6316,6 +6392,11 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -6619,6 +6700,41 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6630,6 +6746,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -6849,6 +6970,29 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lru-memoizer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.2.0.tgz",
+      "integrity": "sha512-QfOZ6jNkxCcM/BkIPnFsqDhtrazLRsghi9mBwFAzol5GCvj4EkFT899Za3+QwikCg5sRX8JstioBDwOxEyzaNw==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "~4.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+      "integrity": "sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==",
+      "dependencies": {
+        "pseudomap": "^1.0.1",
+        "yallist": "^2.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+    },
     "node_modules/magic-string": {
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
@@ -7049,8 +7193,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multer": {
       "version": "1.4.4-lts.1",
@@ -7620,6 +7763,11 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8071,7 +8219,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -8086,7 +8233,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -8097,8 +8243,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -9090,8 +9235,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,8 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "axios": "^1.6.7",
+    "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^3.1.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "uuid": "^9.0.1"
@@ -42,6 +44,7 @@
     "@nestjs/testing": "^10.0.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
+    "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.3.1",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/backend/src/auth/auth.ts
+++ b/backend/src/auth/auth.ts
@@ -1,0 +1,55 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import jwt, { JwtHeader, JwtPayload, SigningKeyCallback } from 'jsonwebtoken';
+import jwksClient, { SigningKey } from 'jwks-rsa';
+import { UserAttribute } from './interface/user-attribute';
+
+@Injectable()
+export class AuthService {
+  async getUserAttributesFromAuthorization(
+    authorization: string,
+  ): Promise<UserAttribute> {
+    if (!authorization.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Invalid token');
+    }
+
+    const url =
+      process.env.KEYCLOAK_CLIENT_ISSUER + '/.well-known/openid-configuration';
+    const response = await fetch(url);
+    const json = await response.json();
+    const client = jwksClient({
+      jwksUri: json.jwks_uri,
+    });
+
+    function getKey(header: JwtHeader, callback: SigningKeyCallback) {
+      client.getSigningKey(header.kid, function (err, key?: SigningKey) {
+        if (err) {
+          callback(err);
+        } else {
+          callback(null, key?.getPublicKey());
+        }
+      });
+    }
+
+    const decodedToken = await new Promise<JwtPayload>((resolve, reject) => {
+      jwt.verify(
+        authorization.replace('Bearer ', ''),
+        getKey,
+        (err, decoded) => {
+          if (err) {
+            reject(new UnauthorizedException('Invalid token'));
+            return;
+          }
+          resolve(decoded as JwtPayload);
+        },
+      );
+    });
+
+    const userAttribute: UserAttribute = {
+      nickname: decodedToken.nickname,
+      age: decodedToken.age,
+      address: decodedToken.address,
+    };
+
+    return userAttribute;
+  }
+}

--- a/backend/src/auth/interface/user-attribute.ts
+++ b/backend/src/auth/interface/user-attribute.ts
@@ -1,0 +1,5 @@
+export class UserAttribute {
+  nickname: string;
+  age: string;
+  address: string;
+}

--- a/backend/src/happiness/dto/create-happiness.dto.ts
+++ b/backend/src/happiness/dto/create-happiness.dto.ts
@@ -1,0 +1,12 @@
+export class CreateHappinessDto {
+  readonly latitude: number;
+  readonly longitude: number;
+  readonly happiness: {
+    happiness1: number;
+    happiness2: number;
+    happiness3: number;
+    happiness4: number;
+    happiness5: number;
+    happiness6: number;
+  };
+}

--- a/backend/src/happiness/happiness.controller.ts
+++ b/backend/src/happiness/happiness.controller.ts
@@ -1,13 +1,33 @@
-import { Controller, Get, Headers, Query } from '@nestjs/common';
+import { Body, Controller, Get, Headers, Post, Query } from '@nestjs/common';
 import { HappinessService } from './happiness.service';
 import { HappinessMeResponse } from './interface/happiness-me.response';
 import { GetHappinessMeDto } from './dto/get-happiness-me.dto';
 import { HappinessAllResponse } from './interface/happiness-all.response';
 import { GetHappinessAllDto } from './dto/get-happiness-all.dto';
+import { AuthService } from 'src/auth/auth';
+import { CreateHappinessDto } from './dto/create-happiness.dto';
+import { HappinessResponse } from './interface/happiness.response';
 
 @Controller('/api/happiness')
 export class HappinessController {
-  constructor(private readonly happinessService: HappinessService) {}
+  constructor(
+    private readonly happinessService: HappinessService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Post()
+  async createHappiness(
+    @Headers('Authorization') authorization: string,
+    @Body() createHappinessDto: CreateHappinessDto,
+  ): Promise<HappinessResponse> {
+    const userAttribute =
+      this.authService.getUserAttributesFromAuthorization(authorization);
+
+    return this.happinessService.postHappiness(
+      await userAttribute,
+      createHappinessDto,
+    );
+  }
 
   @Get('/me')
   async getHapinessMe(

--- a/backend/src/happiness/happiness.controller.ts
+++ b/backend/src/happiness/happiness.controller.ts
@@ -34,8 +34,10 @@ export class HappinessController {
     @Headers('Authorization') authorization: string,
     @Query() getHappinessMeDto: GetHappinessMeDto,
   ): Promise<HappinessMeResponse[]> {
+    const userAttribute =
+      this.authService.getUserAttributesFromAuthorization(authorization);
     return this.happinessService.findHapinessMe(
-      authorization,
+      (await userAttribute).nickname,
       getHappinessMeDto.start,
       getHappinessMeDto.end,
     );

--- a/backend/src/happiness/happiness.module.ts
+++ b/backend/src/happiness/happiness.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { HappinessController } from './happiness.controller';
 import { HappinessService } from './happiness.service';
+import { AuthService } from 'src/auth/auth';
 
 @Module({
   controllers: [HappinessController],
-  providers: [HappinessService],
+  providers: [HappinessService, AuthService],
 })
 export class HappinessModule {}

--- a/backend/src/happiness/happiness.service.ts
+++ b/backend/src/happiness/happiness.service.ts
@@ -46,13 +46,11 @@ export class HappinessService {
   }
 
   async findHapinessMe(
-    authorization: string,
+    nickname: string,
     start: string,
     end: string,
   ): Promise<HappinessMeResponse[]> {
-    const query = `nickname==${this.getNicknameFromToken(
-      authorization,
-    )};timestamp>=${start};timestamp<=${end}`;
+    const query = `nickname==${nickname};timestamp>=${start};timestamp<=${end}`;
     const happinessEntities = await this.getHappinessEntities(query);
     return this.toHappinessMeResponse(happinessEntities);
   }

--- a/backend/src/happiness/happiness.service.ts
+++ b/backend/src/happiness/happiness.service.ts
@@ -79,12 +79,6 @@ export class HappinessService {
     };
   }
 
-  // TODO: authorizationからニックネームを取得する
-  private getNicknameFromToken(authorization: string): string {
-    console.log(authorization);
-    return 'nickname';
-  }
-
   private createEntities(
     userAttribute: UserAttribute,
     body: CreateHappinessDto,

--- a/backend/src/happiness/happiness.service.ts
+++ b/backend/src/happiness/happiness.service.ts
@@ -2,12 +2,19 @@ import axios from 'axios';
 import { HappinessEntities } from './interface/happiness-entities';
 import { HappinessMeResponse } from './interface/happiness-me.response';
 import { v4 as uuidv4 } from 'uuid';
-import { Injectable } from '@nestjs/common';
+import {
+  HttpStatus,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import {
   GraphData,
   HappinessAllResponse,
   MapData,
 } from './interface/happiness-all.response';
+import { CreateHappinessDto } from './dto/create-happiness.dto';
+import { UserAttribute } from 'src/auth/interface/user-attribute';
+import { HappinessResponse } from './interface/happiness.response';
 
 @Injectable()
 export class HappinessService {
@@ -21,6 +28,22 @@ export class HappinessService {
     'happiness5',
     'happiness6',
   ];
+
+  async postHappiness(
+    userAttribute: UserAttribute,
+    body: CreateHappinessDto,
+  ): Promise<HappinessResponse> {
+    const id = uuidv4();
+    const entities = this.createEntities(userAttribute, body, id);
+    await this.postHappinessEntitiy(entities);
+
+    const happinessResponse: HappinessResponse = {
+      message: 'Happiness has been sent.',
+      entity_id: id,
+    };
+
+    return happinessResponse;
+  }
 
   async findHapinessMe(
     authorization: string,
@@ -62,6 +85,91 @@ export class HappinessService {
   private getNicknameFromToken(authorization: string): string {
     console.log(authorization);
     return 'nickname';
+  }
+
+  private createEntities(
+    userAttribute: UserAttribute,
+    body: CreateHappinessDto,
+    id: string,
+  ): HappinessEntities {
+    const formattedData: HappinessEntities = {
+      id: id,
+      type: 'happiness',
+      happiness1: {
+        type: 'Number',
+        value: body.happiness.happiness1,
+      },
+      happiness2: {
+        type: 'Number',
+        value: body.happiness.happiness2,
+      },
+      happiness3: {
+        type: 'Number',
+        value: body.happiness.happiness3,
+      },
+      happiness4: {
+        type: 'Number',
+        value: body.happiness.happiness4,
+      },
+      happiness5: {
+        type: 'Number',
+        value: body.happiness.happiness5,
+      },
+      happiness6: {
+        type: 'Number',
+        value: body.happiness.happiness6,
+      },
+      timestamp: {
+        type: 'DateTime',
+        value: new Date().toISOString(),
+      },
+      nickname: {
+        type: 'Text',
+        value: userAttribute.nickname,
+      },
+      location: {
+        type: 'geo:json',
+        value: {
+          type: 'Point',
+          coordinates: [body.longitude, body.latitude],
+        },
+        metadata: {
+          place: {
+            type: 'Text',
+            value: '東京都渋谷区',
+          },
+        },
+      },
+      age: {
+        type: 'Text',
+        value: userAttribute.age,
+      },
+      address: {
+        type: 'Text',
+        value: userAttribute.address,
+      },
+    };
+
+    return formattedData;
+  }
+
+  private async postHappinessEntitiy(entities: HappinessEntities) {
+    axios
+      .post(`${process.env.ORION_URI}/v2/entities`, entities, {
+        headers: {
+          'Fiware-Service': `${process.env.ORION_FIWARE_SERVICE}`,
+          'Fiware-ServicePath': `${process.env.ORION_FIWARE_SERVICE_PATH}`,
+          'Content-Type': 'application/json',
+        },
+      })
+      .then(function (response) {
+        if (response.status != HttpStatus.CREATED) {
+          throw new InternalServerErrorException();
+        }
+      })
+      .catch(function (error) {
+        throw new InternalServerErrorException(error);
+      });
   }
 
   private async getHappinessEntities(

--- a/backend/src/happiness/interface/happiness.response.ts
+++ b/backend/src/happiness/interface/happiness.response.ts
@@ -1,0 +1,4 @@
+export interface HappinessResponse {
+  message: string;
+  entity_id: string;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -16,6 +16,7 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "esModuleInterop": true
   }
 }

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,6 +14,7 @@ services:
       - "ORION_URI=http://orion:1026"
       - "ORION_FIWARE_SERVICE=Goverment"
       - "ORION_FIWARE_SERVICE_PATH=/Happiness"
+      - "KEYCLOAK_CLIENT_ISSUER=${KEYCLOAK_CLIENT_ISSUER}"
     volumes:
       - ./backend:/app/backend
     networks:


### PR DESCRIPTION
暫定確認の為の手順を記載いたします。

1. Tokenの有効時間を1日に変更
　Realm settings → Tokens → Access tokens → Access Token Lifespan を1Daysに変更
2. Tokenをフロントエンドから取得
　`frontend/src/app/api/auth/[...nextauth]/route.ts` の47行目に以下追加
　`console.log(account.access_token)`
```
43-　    resolve(decoded as JwtPayload)
44-        })
45-      })
46-
47-      console.log(account.access_token)
48-
49-      token.nickname = decodedToken.nickname
```

3. consoleに出力されたTokenを以下サンプルリクエストの`Authorization`に設定
　※先頭にBearer を付与してください

動作確認コマンドは以下PRに記載させて頂いております。
https://github.com/c-3lab/oasismap/pull/50#issue-2161066547