### PR TITLE
リフレッシュトークンのタイムアウト時間の変更

### DIFF
--- a/keycloak/variables.json
+++ b/keycloak/variables.json
@@ -38,11 +38,11 @@
         },
         {
             "key": "RealmSSOSessionIdleTimeout",
-            "value": 1800
+            "value": 86400
         },
         {
             "key": "RealmSSOSessionMaxLifespan",
-            "value": 36000
+            "value": 7776000
         },
         {
             "key": "GoogleClientID",


### PR DESCRIPTION
- SSO Session Idle ：24時間
ユーザーがアクティビティを行わずに一定時間経過した場合に、
セッションが自動的にログアウトされるまでの時間
 
- SSO Session Max ：90日
ユーザーのセッションが強制的にログアウトされるまでの最大時間
アクティビティがあっても、この時間が過ぎるとログアウトされる