### PR TITLE
幸福度を入力していない状態の一覧表示画面のデザインを修正

### DIFF
--- a/frontend/src/app/happiness/list/page.tsx
+++ b/frontend/src/app/happiness/list/page.tsx
@@ -20,6 +20,7 @@ const HappinessList: React.FC = () => {
   const { update } = useSession()
   const [listData, setListData] = useState<Data[]>([])
   const willStop = useRef(false)
+  const [isLoaded, setIsLoaded] = useState(false)
 
   const getData = async () => {
     try {
@@ -61,6 +62,8 @@ const HappinessList: React.FC = () => {
           MessageType.Error
         )
       }
+    } finally {
+      setIsLoaded(true)
     }
   }
 
@@ -107,9 +110,11 @@ const HappinessList: React.FC = () => {
 
   return (
     <Grid sx={{ p: '16px' }}>
-      {listData.length >= 1 && (
-        <ListTable listData={listData} deleteListData={deleteListData} />
-      )}
+      <ListTable
+        listData={listData}
+        deleteListData={deleteListData}
+        isLoaded={isLoaded}
+      />
     </Grid>
   )
 }

--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -25,6 +25,7 @@ import DeleteConfirmationDialog from '@/components/happiness/delete-confirmation
 interface ListTableProps {
   listData: Data[]
   deleteListData: (id: string) => void
+  isLoaded: boolean
 }
 
 interface RowProps {
@@ -107,7 +108,11 @@ const Row: React.FC<RowProps> = ({ row, openDialog }) => {
   )
 }
 
-const ListTable: React.FC<ListTableProps> = ({ listData, deleteListData }) => {
+const ListTable: React.FC<ListTableProps> = ({
+  listData,
+  deleteListData,
+  isLoaded,
+}) => {
   const [selectedData, setSelectedData] = useState<Data | null>(null)
 
   const deleteRowData = () => {
@@ -151,13 +156,21 @@ const ListTable: React.FC<ListTableProps> = ({ listData, deleteListData }) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {listData.map((row) => (
-            <Row
-              key={row.id}
-              row={row}
-              openDialog={() => setSelectedData(row)}
-            />
-          ))}
+          {isLoaded === true && listData.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={8} sx={{ textAlign: 'center' }}>
+                データがありません
+              </TableCell>
+            </TableRow>
+          ) : (
+            listData.map((row) => (
+              <Row
+                key={row.id}
+                row={row}
+                openDialog={() => setSelectedData(row)}
+              />
+            ))
+          )}
         </TableBody>
       </Table>
       <DeleteConfirmationDialog


### PR DESCRIPTION
https://github.com/c-3lab/oasismap/issues/207
幸福度が存在しないことを示すために表のヘッダーを表示させ、「データがありません」と表示されるように変更。