### PR TITLE
一覧画面でのソート機能の追加

### DIFF
--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -16,6 +16,7 @@ import {
   MenuItem,
   ListItemIcon,
   ListItemText,
+  TableSortLabel,
 } from '@mui/material'
 import {
   CheckCircle,
@@ -28,6 +29,7 @@ import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
 import { Data } from '@/types/happiness-list-response'
 import { timestampToDateTime } from '@/libs/date-converter'
 import DeleteConfirmationDialog from '@/components/happiness/delete-confirmation-dialog'
+import SwapVertIcon from '@mui/icons-material/SwapVert'
 
 interface ListTableProps {
   listData: Data[]
@@ -158,6 +160,47 @@ const ListTable: React.FC<ListTableProps> = ({
   isLoaded,
 }) => {
   const [selectedData, setSelectedData] = useState<Data | null>(null)
+  const [order, setOrder] = useState<Order>('desc')
+  const [orderBy, setOrderBy] = useState<Key | null>(null)
+  const [iconView, setIconView] = useState<boolean>(true)
+  type Key =
+    | 'happiness1'
+    | 'happiness2'
+    | 'happiness3'
+    | 'happiness4'
+    | 'happiness5'
+    | 'happiness6'
+  function sortedRows(
+    order: Order,
+    orderBy: Key | null
+  ): (a: Data, b: Data) => number {
+    return order === 'asc'
+      ? (a, b) => descendinComparator(a, b, orderBy)
+      : (a, b) => -descendinComparator(a, b, orderBy)
+  }
+  type Order = 'asc' | 'desc'
+  function descendinComparator(a: Data, b: Data, orderBy: Key | null) {
+    if (orderBy !== null && b.answers[orderBy] < a.answers[orderBy]) {
+      return 1
+    }
+    if (orderBy !== null && b.answers[orderBy] > a.answers[orderBy]) {
+      return -1
+    }
+    return 0
+  }
+  const handleRequestSort = (property: Key) => {
+    if (order === 'asc') {
+      setOrder('desc')
+      setOrderBy(null)
+      setIconView(true)
+      return
+    }
+    const isAsc = orderBy === property && order === 'desc'
+    setOrder(isAsc ? 'asc' : 'desc')
+    setOrderBy(property)
+    setIconView(false)
+  }
+  const visibleRows = [...listData].sort(sortedRows(order, orderBy))
 
   const deleteRowData = () => {
     if (selectedData) {
@@ -190,12 +233,90 @@ const ListTable: React.FC<ListTableProps> = ({
             }}
           >
             <TableCell sx={{ pl: '8px', width: '28px' }} />
-            <TableCell>ワクワク</TableCell>
-            <TableCell>学び</TableCell>
-            <TableCell>ホッとする</TableCell>
-            <TableCell>自分を取り戻せる</TableCell>
-            <TableCell>自慢</TableCell>
-            <TableCell>思い出</TableCell>
+            <TableCell>
+              <TableSortLabel
+                onClick={() => handleRequestSort('happiness1')}
+                active={orderBy === 'happiness1' || iconView}
+                direction={order}
+                IconComponent={iconView === false ? undefined : SwapVertIcon}
+                sx={{
+                  flexFlow: { xs: 'column', sm: 'row' },
+                  mx: { xs: 0, sm: '4px' },
+                }}
+              >
+                ワクワク
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                onClick={() => handleRequestSort('happiness2')}
+                active={orderBy === 'happiness2' || iconView}
+                direction={order}
+                IconComponent={iconView === false ? undefined : SwapVertIcon}
+                sx={{
+                  flexFlow: { xs: 'column', sm: 'row' },
+                  mx: { xs: 0, sm: '4px' },
+                }}
+              >
+                学び
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                onClick={() => handleRequestSort('happiness3')}
+                active={orderBy === 'happiness3' || iconView}
+                direction={order}
+                IconComponent={iconView === false ? undefined : SwapVertIcon}
+                sx={{
+                  flexFlow: { xs: 'column', sm: 'row' },
+                  mx: { xs: 0, sm: '4px' },
+                }}
+              >
+                ホッとする
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                onClick={() => handleRequestSort('happiness4')}
+                active={orderBy === 'happiness4' || iconView}
+                direction={order}
+                IconComponent={iconView === false ? undefined : SwapVertIcon}
+                sx={{
+                  flexFlow: { xs: 'column', sm: 'row' },
+                  mx: { xs: 0, sm: '4px' },
+                }}
+              >
+                自分を取り戻せる
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                onClick={() => handleRequestSort('happiness5')}
+                active={orderBy === 'happiness5' || iconView}
+                direction={order}
+                IconComponent={iconView === false ? undefined : SwapVertIcon}
+                sx={{
+                  flexFlow: { xs: 'column', sm: 'row' },
+                  mx: { xs: 0, sm: '4px' },
+                }}
+              >
+                自慢
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                onClick={() => handleRequestSort('happiness6')}
+                active={orderBy === 'happiness6' || iconView}
+                direction={order}
+                IconComponent={iconView === false ? undefined : SwapVertIcon}
+                sx={{
+                  flexFlow: { xs: 'column', sm: 'row' },
+                  mx: { xs: 0, sm: '4px' },
+                }}
+              >
+                思い出
+              </TableSortLabel>
+            </TableCell>
             <TableCell sx={{ width: '28px' }} />
           </TableRow>
         </TableHead>
@@ -207,7 +328,7 @@ const ListTable: React.FC<ListTableProps> = ({
               </TableCell>
             </TableRow>
           ) : (
-            listData.map((row) => (
+            visibleRows.map((row: any) => (
               <Row
                 key={row.id}
                 row={row}

--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -241,7 +241,7 @@ const ListTable: React.FC<ListTableProps> = ({
     >
       <Table
         stickyHeader
-        sx={{ px: '16px', tableLayout: 'fixed', width: '100%' }}
+        sx={{ px: '8px 4px', tableLayout: 'fixed', width: '100%' }}
       >
         <TableHead>
           <TableRow
@@ -255,7 +255,12 @@ const ListTable: React.FC<ListTableProps> = ({
           >
             <TableCell sx={{ pl: '8px', width: '28px' }} />
             {tableCellCategories.map(({ title, key }) => (
-              <TableCell key={key}>
+              <TableCell
+                key={key}
+                sx={{
+                  padding: '16px 4px',
+                }}
+              >
                 <TableSortLabel
                   onClick={() => handleSort(key)}
                   active={orderBy === key || orderBy === null}
@@ -264,6 +269,9 @@ const ListTable: React.FC<ListTableProps> = ({
                   sx={{
                     flexFlow: { xs: 'column', sm: 'row' },
                     mx: { xs: 0, sm: '4px' },
+                    '& .MuiTableSortLabel-icon': {
+                      paddingTop: '5px',
+                    },
                   }}
                 >
                   {title}

--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -171,15 +171,15 @@ const Row: React.FC<RowProps> = ({ row, openDialog }) => {
   )
 }
 
-function Comparator(
+function getComparator(
   order: Order,
   orderBy: HappinessKey
 ): (a: Data, b: Data) => number {
   return order === 'asc'
-    ? (a, b) => ascending(a, b, orderBy)
-    : (a, b) => -ascending(a, b, orderBy)
+    ? (a, b) => ascendingComparator(a, b, orderBy)
+    : (a, b) => -ascendingComparator(a, b, orderBy)
 }
-function ascending(a: Data, b: Data, orderBy: HappinessKey) {
+function ascendingComparator(a: Data, b: Data, orderBy: HappinessKey) {
   if (b.answers[orderBy] < a.answers[orderBy]) {
     return 1
   } else {
@@ -220,7 +220,7 @@ const ListTable: React.FC<ListTableProps> = ({
   const sortedListData =
     order === undefined || orderBy === null
       ? [...listData]
-      : [...listData].sort(Comparator(order, orderBy))
+      : [...listData].sort(getComparator(order, orderBy))
 
   const deleteRowData = () => {
     if (selectedData) {

--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -217,7 +217,7 @@ const ListTable: React.FC<ListTableProps> = ({
       return
     }
   }
-  const sortListData =
+  const sortedListData =
     order === undefined || orderBy === null
       ? [...listData]
       : [...listData].sort(Comparator(order, orderBy))
@@ -280,7 +280,7 @@ const ListTable: React.FC<ListTableProps> = ({
               </TableCell>
             </TableRow>
           ) : (
-            sortListData.map((row: any) => (
+            sortedListData.map((row: any) => (
               <Row
                 key={row.id}
                 row={row}

--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -241,7 +241,7 @@ const ListTable: React.FC<ListTableProps> = ({
     >
       <Table
         stickyHeader
-        sx={{ px: '8px 4px', tableLayout: 'fixed', width: '100%' }}
+        sx={{ px: '8px', tableLayout: 'fixed', width: '100%' }}
       >
         <TableHead>
           <TableRow
@@ -270,7 +270,10 @@ const ListTable: React.FC<ListTableProps> = ({
                     flexFlow: { xs: 'column', sm: 'row' },
                     mx: { xs: 0, sm: '4px' },
                     '& .MuiTableSortLabel-icon': {
-                      paddingTop: '5px',
+                      paddingTop: {
+                        xs: '5px',
+                        sm: 0,
+                      },
                     },
                   }}
                 >

--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -163,6 +163,18 @@ const ListTable: React.FC<ListTableProps> = ({
   const [order, setOrder] = useState<Order>('desc')
   const [orderBy, setOrderBy] = useState<Key | null>(null)
   const [iconView, setIconView] = useState<boolean>(true)
+  interface TableCellCategories {
+    title: string
+    key: Key
+  }
+  const tableCellCategories: TableCellCategories[] = [
+    { title: 'ワクワク', key: 'happiness1' },
+    { title: '学び', key: 'happiness2' },
+    { title: 'ホッとする', key: 'happiness3' },
+    { title: '自分を取り戻せる', key: 'happiness4' },
+    { title: '自慢', key: 'happiness5' },
+    { title: '思い出', key: 'happiness6' },
+  ]
   type Key =
     | 'happiness1'
     | 'happiness2'
@@ -233,90 +245,22 @@ const ListTable: React.FC<ListTableProps> = ({
             }}
           >
             <TableCell sx={{ pl: '8px', width: '28px' }} />
-            <TableCell>
-              <TableSortLabel
-                onClick={() => handleRequestSort('happiness1')}
-                active={orderBy === 'happiness1' || iconView}
-                direction={order}
-                IconComponent={iconView === false ? undefined : SwapVertIcon}
-                sx={{
-                  flexFlow: { xs: 'column', sm: 'row' },
-                  mx: { xs: 0, sm: '4px' },
-                }}
-              >
-                ワクワク
-              </TableSortLabel>
-            </TableCell>
-            <TableCell>
-              <TableSortLabel
-                onClick={() => handleRequestSort('happiness2')}
-                active={orderBy === 'happiness2' || iconView}
-                direction={order}
-                IconComponent={iconView === false ? undefined : SwapVertIcon}
-                sx={{
-                  flexFlow: { xs: 'column', sm: 'row' },
-                  mx: { xs: 0, sm: '4px' },
-                }}
-              >
-                学び
-              </TableSortLabel>
-            </TableCell>
-            <TableCell>
-              <TableSortLabel
-                onClick={() => handleRequestSort('happiness3')}
-                active={orderBy === 'happiness3' || iconView}
-                direction={order}
-                IconComponent={iconView === false ? undefined : SwapVertIcon}
-                sx={{
-                  flexFlow: { xs: 'column', sm: 'row' },
-                  mx: { xs: 0, sm: '4px' },
-                }}
-              >
-                ホッとする
-              </TableSortLabel>
-            </TableCell>
-            <TableCell>
-              <TableSortLabel
-                onClick={() => handleRequestSort('happiness4')}
-                active={orderBy === 'happiness4' || iconView}
-                direction={order}
-                IconComponent={iconView === false ? undefined : SwapVertIcon}
-                sx={{
-                  flexFlow: { xs: 'column', sm: 'row' },
-                  mx: { xs: 0, sm: '4px' },
-                }}
-              >
-                自分を取り戻せる
-              </TableSortLabel>
-            </TableCell>
-            <TableCell>
-              <TableSortLabel
-                onClick={() => handleRequestSort('happiness5')}
-                active={orderBy === 'happiness5' || iconView}
-                direction={order}
-                IconComponent={iconView === false ? undefined : SwapVertIcon}
-                sx={{
-                  flexFlow: { xs: 'column', sm: 'row' },
-                  mx: { xs: 0, sm: '4px' },
-                }}
-              >
-                自慢
-              </TableSortLabel>
-            </TableCell>
-            <TableCell>
-              <TableSortLabel
-                onClick={() => handleRequestSort('happiness6')}
-                active={orderBy === 'happiness6' || iconView}
-                direction={order}
-                IconComponent={iconView === false ? undefined : SwapVertIcon}
-                sx={{
-                  flexFlow: { xs: 'column', sm: 'row' },
-                  mx: { xs: 0, sm: '4px' },
-                }}
-              >
-                思い出
-              </TableSortLabel>
-            </TableCell>
+            {tableCellCategories.map(({ title, key }) => (
+              <TableCell key={key}>
+                <TableSortLabel
+                  onClick={() => handleRequestSort(key)}
+                  active={orderBy === key || iconView}
+                  direction={order}
+                  IconComponent={iconView === false ? undefined : SwapVertIcon}
+                  sx={{
+                    flexFlow: { xs: 'column', sm: 'row' },
+                    mx: { xs: 0, sm: '4px' },
+                  }}
+                >
+                  {title}
+                </TableSortLabel>
+              </TableCell>
+            ))}
             <TableCell sx={{ width: '28px' }} />
           </TableRow>
         </TableHead>

--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -59,6 +59,23 @@ const tableCellCategories: TableCellCategories[] = [
   { title: '思い出', key: 'happiness6' },
 ]
 
+function getComparator(
+  order: Order,
+  orderBy: HappinessKey
+): (a: Data, b: Data) => number {
+  return order === 'asc'
+    ? (a, b) => ascendingComparator(a, b, orderBy)
+    : (a, b) => -ascendingComparator(a, b, orderBy)
+}
+
+function ascendingComparator(a: Data, b: Data, orderBy: HappinessKey) {
+  if (b.answers[orderBy] < a.answers[orderBy]) {
+    return 1
+  } else {
+    return -1
+  }
+}
+
 const Row: React.FC<RowProps> = ({ row, openDialog }) => {
   const [isCollapseOpen, setIsCollapseOpen] = useState(false)
   const [anchorElement, setAnchorElement] = React.useState<null | HTMLElement>(
@@ -169,22 +186,6 @@ const Row: React.FC<RowProps> = ({ row, openDialog }) => {
       </Menu>
     </>
   )
-}
-
-function getComparator(
-  order: Order,
-  orderBy: HappinessKey
-): (a: Data, b: Data) => number {
-  return order === 'asc'
-    ? (a, b) => ascendingComparator(a, b, orderBy)
-    : (a, b) => -ascendingComparator(a, b, orderBy)
-}
-function ascendingComparator(a: Data, b: Data, orderBy: HappinessKey) {
-  if (b.answers[orderBy] < a.answers[orderBy]) {
-    return 1
-  } else {
-    return -1
-  }
 }
 
 const ListTable: React.FC<ListTableProps> = ({


### PR DESCRIPTION
https://github.com/c-3lab/oasismap/issues/209
@hasebetakumi 
一覧画面で各項目ごとに昇順、降順でソートできる機能を追加しました。