### PR TITLE
セキュリティ対応（Critical）　postgres:17.2

### DIFF
--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -116,7 +116,9 @@ services:
         tag: mongo-cli
 
   postgres-cli:
-    image: postgres:17.2
+    build:
+      context: ./postgres
+      dockerfile: Dockerfile
     hostname: postgres-cli
     container_name: postgres-cli
     environment:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -95,7 +95,9 @@ services:
     restart: always
 
   postgres:
-    image: postgres:16.1
+    build:
+      context: ./postgres
+      dockerfile: Dockerfile
     hostname: postgres
     expose:
       - "5432"
@@ -121,7 +123,9 @@ services:
     restart: always
 
   postgres-cli:
-    image: postgres:16.1
+    build:
+      context: ./postgres
+      dockerfile: Dockerfile
     hostname: postgres-cli
     container_name: postgres-cli
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,9 @@ services:
     restart: always
 
   postgres:
-    image: postgres:17.2
+    build:
+      context: ./postgres
+      dockerfile: Dockerfile
     hostname: postgres
     expose:
       - "5432"
@@ -144,7 +146,9 @@ services:
     entrypoint: "mongosh 'mongodb://${MONGOUSERNAME}:${MONGOPASSWORD}@mongo:27017/oriondb-government?authSource=admin' --file '/tmp/scripts/add-mongo-index.js'"
 
   postgres-cli:
-    image: postgres:17.2
+    build:
+      context: ./postgres
+      dockerfile: Dockerfile
     hostname: postgres-cli
     container_name: postgres-cli
     depends_on:

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,61 @@
+# Dockerfile to fix CRITICAL vulnerabilities in gosu and system packages
+# Based on FROM postgres:17.5 but builds gosu with Go 1.22.4 and updates vulnerable packages
+
+FROM postgres:17.5
+
+RUN set -eux; \
+    # Save the list of packages that were originally installed (sorted for later diff)
+    saved_pkgs_file="/tmp/pkgs.before"; \
+    dpkg-query -W -f='${Package}\n' | sort > "${saved_pkgs_file}"; \
+    \
+    # Install minimal tools required for building (may or may not be present originally)
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl git build-essential; \
+    \
+    # --- Temporarily install Go 1.22.4 (amd64) ---
+    cd /tmp; \
+    curl -fsSLO "https://go.dev/dl/go1.22.4.linux-amd64.tar.gz"; \
+    tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz; \
+    export PATH="/usr/local/go/bin:$PATH"; \
+    \
+    # --- Build gosu v1.17 with Go 1.22.4 (static binary) ---
+    mkdir -p /tmp/gosu-src; \
+    curl -fsSL -o /tmp/gosu-src/gosu.tar.gz "https://github.com/tianon/gosu/archive/refs/tags/1.17.tar.gz"; \
+    tar -C /tmp/gosu-src -xzf /tmp/gosu-src/gosu.tar.gz --strip-components=1; \
+    cd /tmp/gosu-src; \
+    go mod download; \
+    CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags="-s -w" -o /usr/local/bin/gosu .; \
+    chmod +x /usr/local/bin/gosu; \
+    /usr/local/bin/gosu --version; \
+    \
+    # --- Update vulnerable packages to fix security issues ---
+    cd /; \
+    # Add trixie (testing) repository for newer package versions (including SQLite 3.50.2+)
+    echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list; \
+    # Update package lists and upgrade vulnerable packages
+    apt-get update && apt-get upgrade -y; \
+    # Install specific package versions from trixie if available
+    apt-get install -y --no-install-recommends \
+        libsqlite3-0/trixie \
+        libgssapi-krb5-2/trixie \
+        libk5crypto3/trixie \
+        libkrb5-3/trixie \
+        libkrb5support0/trixie || apt-get install -y libsqlite3-0; \
+    \
+    # --- Cleanup build artifacts and Go toolchain ---
+    cd /; \
+    \
+    # Determine which packages were newly installed during this build and remove only those
+    current_pkgs_file="/tmp/pkgs.after"; \
+    dpkg-query -W -f='${Package}\n' | sort > "${current_pkgs_file}"; \
+    # Extract packages that exist in 'after' but not in 'before' (i.e., newly added)
+    to_remove="$(comm -13 "${saved_pkgs_file}" "${current_pkgs_file}" \
+      | grep -E '^(git|build-essential|curl|ca-certificates)$' || true)"; \
+    if [ -n "${to_remove}" ]; then \
+      apt-get purge -y --auto-remove ${to_remove}; \
+    fi; \
+    rm -f "${saved_pkgs_file}" "${current_pkgs_file}"; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    # Now clean up Go toolchain and temp files
+    rm -rf /usr/local/go /tmp/*


### PR DESCRIPTION
*1. docker-compose.ymlを利用し環境を立ち上げ動作確認する*

- 幸福度データ取得・検索
<img width="1914" height="946" alt="image" src="https://github.com/user-attachments/assets/483670bf-b4e0-4829-937e-9a70b238c789" />

- 幸福度データ登録
<img width="1862" height="924" alt="image" src="https://github.com/user-attachments/assets/4545bc80-647e-4697-ab33-8da8e932be37" />
<img width="1706" height="150" alt="image" src="https://github.com/user-attachments/assets/a4dd96db-4f34-4959-bcfe-1f6e126ed40b" />


- 幸福度データ削除
before delete:
<img width="1903" height="598" alt="image" src="https://github.com/user-attachments/assets/fdd9c5d5-3033-49fb-89e2-85694cea259e" />

affter Delete : 
<img width="1916" height="289" alt="image" src="https://github.com/user-attachments/assets/bb8f7eb0-dd7a-4869-ac06-bdeca93c981f" />

Delete in DB
<img width="1687" height="147" alt="image" src="https://github.com/user-attachments/assets/af8f4b35-1053-4259-8f48-16c163e15301" />


- 幸福度データインポート
<img width="975" height="229" alt="image" src="https://github.com/user-attachments/assets/1a85117f-884e-4394-ad37-66211d3f1455" />


<img width="1907" height="268" alt="image" src="https://github.com/user-attachments/assets/facf63be-6103-4bc4-9f0f-687168839498" />

<img width="1911" height="939" alt="image" src="https://github.com/user-attachments/assets/e8887391-b50c-4ec6-a453-63edec317c1b" />


<img width="1697" height="281" alt="image" src="https://github.com/user-attachments/assets/ed9da4d8-478a-42c4-a2b9-a8994fca8de3" />


- 幸福度データエクスポート
<img width="1317" height="608" alt="image" src="https://github.com/user-attachments/assets/7e222bdc-c7e0-4e70-8d2e-f8ea0a75c86e" />


- postgres-cliのentrypointで指定しているコマンド
<img width="434" height="574" alt="image" src="https://github.com/user-attachments/assets/8e07e604-a75b-437e-9c26-492053b0495a" />


*2. docker-compose-dev.ymlを利用し環境を立ち上げ動作確認する*

- 幸福度データ取得・検索
<img width="1916" height="949" alt="image" src="https://github.com/user-attachments/assets/4e02014c-9583-43ca-b90c-3dc6bf1cc811" />

- 幸福度データ登録
<img width="1914" height="979" alt="image" src="https://github.com/user-attachments/assets/4d0df602-be34-44b3-83cc-fa28401c291d" />


- 幸福度データ削除
<img width="1904" height="564" alt="image" src="https://github.com/user-attachments/assets/8a0f5833-7f36-4c0c-9c1a-76a7bfe77708" />
<img width="1908" height="713" alt="image" src="https://github.com/user-attachments/assets/099e312b-0527-4ec4-9c97-10cb6a5a82f2" />
<img width="1913" height="966" alt="image" src="https://github.com/user-attachments/assets/c45423d3-2cae-4e13-b944-2904523a27c2" />


- 幸福度データインポート
<img width="956" height="245" alt="image" src="https://github.com/user-attachments/assets/462842b5-645f-4c17-ae86-881cbb3c016c" />

<img width="1908" height="287" alt="image" src="https://github.com/user-attachments/assets/2f2c78a4-cbee-469c-b597-fd9f125b7434" />

<img width="1693" height="334" alt="image" src="https://github.com/user-attachments/assets/9137a7ed-9054-4984-a5b2-67f17238b5d4" />

- 幸福度データエクスポート
<img width="1338" height="363" alt="image" src="https://github.com/user-attachments/assets/2286b511-76d3-4d34-9f9f-4813f0c00ad0" />


**docker-compose-azureを利用しpostgres-cliコンテナを立ち上げ、entrypointに指定してあるスクリプトの動作確認を行う**

`docker run -d --name test-postgres -e POSTGRES_PASSWORD=testpass -e POSTGRES_USER=testuser -e POSTGRES_DB=postgres -p 5433:5432 postgres:17.5`
<img width="821" height="71" alt="image" src="https://github.com/user-attachments/assets/ff362503-cf0c-4995-8c5a-07e52b14ad00" />

`docker network connect oasismap_backend-network test-postgres`

`docker compose -f docker-compose-azure.yml --env-file env.test up postgres-cli`
<img width="894" height="229" alt="image" src="https://github.com/user-attachments/assets/36eefc92-a87f-4bc1-8d0c-3667ab829103" />

`docker exec test-postgres psql -U testuser -d cygnus -c "\d government.happiness"`
<img width="925" height="589" alt="image" src="https://github.com/user-attachments/assets/de9ab575-6c1d-4d48-809b-e45b7756d852" />


*3. Trivyを実行し、結果を本Issueにコメントする*
`trivy image postgres:17.5 --format table > postgres.17.5.txt`
[postgres.17.5.txt](https://github.com/user-attachments/files/21750477/postgres.17.5.txt)

```
postgres:17.5 (debian 12.11)
============================
Total: 171 (UNKNOWN: 1, LOW: 123, MEDIUM: 26, HIGH: 16, CRITICAL: 5)

usr/local/bin/gosu (gobinary)
=============================
Total: 62 (UNKNOWN: 0, LOW: 1, MEDIUM: 26, HIGH: 32, CRITICAL: 3)

```
*4. Criticalアラートが無くなっているか確認する*
`trivy image postgres:17.5 --severity CRITICAL --format table > postgres.17.5-critical.txt`
[mongo.8.0.12-critical.txt](https://github.com/user-attachments/files/21675700/mongo.8.0.12-critical.txt)

```
postgres:17.5 (debian 12.11)
============================
Total: 5 (CRITICAL: 5)
```
<img width="1280" height="468" alt="image" src="https://github.com/user-attachments/assets/5b5414db-9edc-4d74-a11f-34c52cb29da8" />

```
usr/local/bin/gosu (gobinary)
=============================
Total: 3 (CRITICAL: 3)
```
<img width="1163" height="389" alt="image" src="https://github.com/user-attachments/assets/720d2374-7aa5-4f42-a0df-ceed7418f94a" />


*5. Criticalが残っている場合*

**Criticalの原因となっているパッケージのバージョンアップを行う記述をDockerfileに追記する。**
https://github.com/c-3lab/oasismap/pull/326/files#diff-b310706a0c1c47b4634699420ecd4dfbeb10bbc435d95f5f5e8ab36d4e9f9c36R1-R65

**Trivyを実行し、結果を本Issueにコメントする**
`trivy image oasismap-postgres:latest --severity CRITICAL --format table`
<img width="1000" height="506" alt="image" src="https://github.com/user-attachments/assets/0e59de91-bef5-4d39-8cf2-785e2c5ccaa7" />


