### PR TITLE
幸福度入力画面に現在地を表示する地図追加

### DIFF
--- a/frontend/src/app/happiness/input/page.tsx
+++ b/frontend/src/app/happiness/input/page.tsx
@@ -80,8 +80,6 @@ const HappinessInput: React.FC = () => {
     setExif(null)
     const newMode = event.target.value as 'current' | 'past'
     setMode(newMode)
-
-    // Lấy vị trí hiện tại khi chuyển sang mode past
     if (newMode === 'past' && !currentPosition) {
       try {
         const position = await getCurrentPosition()

--- a/frontend/src/app/happiness/input/page.tsx
+++ b/frontend/src/app/happiness/input/page.tsx
@@ -154,17 +154,11 @@ const HappinessInput: React.FC = () => {
 
     try {
       const rawExif = await exifr.parse(image)
-      // const exif = {
-      //   timestamp: rawExif?.CreateDate,
-      //   latitude: isNaN(rawExif?.latitude) ? undefined : rawExif?.latitude,
-      //   longitude: isNaN(rawExif?.longitude) ? undefined : rawExif?.longitude,
-      // }
       const exif = {
-        timestamp: rawExif?.CreateDate || new Date('2024-01-15T10:30:00Z'),
-        latitude: 35.97005, // Tokyo latitude
-        longitude: 139.3981472222222, // Tokyo longitude
+        timestamp: rawExif?.CreateDate,
+        latitude: isNaN(rawExif?.latitude) ? undefined : rawExif?.latitude,
+        longitude: isNaN(rawExif?.longitude) ? undefined : rawExif?.longitude,
       }
-
       let missingFields: string[] = []
       if (exif.timestamp === undefined) missingFields.push('撮影日時')
       if (exif.latitude === undefined) missingFields.push('緯度')

--- a/frontend/src/app/happiness/input/page.tsx
+++ b/frontend/src/app/happiness/input/page.tsx
@@ -74,6 +74,11 @@ const HappinessInput: React.FC = () => {
     longitude: number
   } | null>(null)
 
+  // Get current position on component mount
+  React.useEffect(() => {
+    updateCurrentPosition()
+  }, [])
+
   const getCurrentPositionForPayload = async () => {
     const position = await getCurrentPosition()
     if (position.latitude === undefined || position.longitude === undefined)
@@ -84,27 +89,29 @@ const HappinessInput: React.FC = () => {
     }
   }
 
+  // Common function to update current position
+  const updateCurrentPosition = async () => {
+    try {
+      const position = await getCurrentPosition()
+      if (position.latitude !== undefined && position.longitude !== undefined) {
+        setCurrentPosition({
+          latitude: position.latitude,
+          longitude: position.longitude,
+        })
+      }
+    } catch (error) {
+      console.error('Error getting current position:', error)
+    }
+  }
+
   // 入力モード選択用ラジオボタンの状態を変更
   const handleMode = async (event: React.ChangeEvent<HTMLInputElement>) => {
     setErrors(errors.filter((error) => error.field !== 'image'))
     setExif(null)
     const newMode = event.target.value as 'current' | 'past'
     setMode(newMode)
-    if (newMode === 'past' && !currentPosition) {
-      try {
-        const position = await getCurrentPosition()
-        if (
-          position.latitude !== undefined &&
-          position.longitude !== undefined
-        ) {
-          setCurrentPosition({
-            latitude: position.latitude,
-            longitude: position.longitude,
-          })
-        }
-      } catch (error) {
-        console.error('Error getting current position:', error)
-      }
+    if (!currentPosition) {
+      await updateCurrentPosition()
     }
   }
 
@@ -278,18 +285,16 @@ const HappinessInput: React.FC = () => {
           />
         </RadioGroup>
 
-        {/* Map display only for past mode */}
-        {mode === 'past' && (
-          <Box
-            sx={{ height: '300px', marginTop: '16px', marginBottom: '16px' }}
-          >
-            <PreviewMap
-              latitude={exif?.latitude ?? currentPosition?.latitude ?? 0}
-              longitude={exif?.longitude ?? currentPosition?.longitude ?? 0}
-              answer={checkboxValues}
-            />
-          </Box>
-        )}
+        {/* Map display always */}
+        <Box sx={{ height: '300px', marginTop: '16px', marginBottom: '16px' }}>
+          <PreviewMap
+            latitude={exif?.latitude ?? currentPosition?.latitude ?? 35.6581064}
+            longitude={
+              exif?.longitude ?? currentPosition?.longitude ?? 139.7413637
+            }
+            answer={checkboxValues}
+          />
+        </Box>
 
         <List dense disablePadding>
           {Object.entries(checkboxValues).map(([key, value]) => (

--- a/frontend/src/app/happiness/input/page.tsx
+++ b/frontend/src/app/happiness/input/page.tsx
@@ -83,10 +83,7 @@ const HappinessInput: React.FC = () => {
     const position = await getCurrentPosition()
     if (position.latitude === undefined || position.longitude === undefined)
       throw new Error('Geolocation is not available')
-    return {
-      latitude: position.latitude,
-      longitude: position.longitude,
-    }
+    return position
   }
 
   // Common function to update current position
@@ -94,10 +91,7 @@ const HappinessInput: React.FC = () => {
     try {
       const position = await getCurrentPosition()
       if (position.latitude !== undefined && position.longitude !== undefined) {
-        setCurrentPosition({
-          latitude: position.latitude,
-          longitude: position.longitude,
-        })
+        setCurrentPosition(position)
       }
     } catch (error) {
       console.error('Error getting current position:', error)

--- a/frontend/src/app/happiness/input/page.tsx
+++ b/frontend/src/app/happiness/input/page.tsx
@@ -105,14 +105,10 @@ const HappinessInput: React.FC = () => {
   }
 
   // 入力モード選択用ラジオボタンの状態を変更
-  const handleMode = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleMode = (event: React.ChangeEvent<HTMLInputElement>) => {
     setErrors(errors.filter((error) => error.field !== 'image'))
     setExif(null)
-    const newMode = event.target.value as 'current' | 'past'
-    setMode(newMode)
-    if (!currentPosition) {
-      await updateCurrentPosition()
-    }
+    setMode(event.target.value as 'current' | 'past')
   }
 
   // チェックボックスの状態が全て0かどうかをチェック
@@ -154,7 +150,6 @@ const HappinessInput: React.FC = () => {
   const handleImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
     setErrors(errors.filter((error) => error.field !== 'image'))
     setExif(null)
-    setCurrentPosition(null) // Reset current position when new image is selected
 
     const image = event.target.files?.[0]
     if (!image) return
@@ -214,22 +209,16 @@ const HappinessInput: React.FC = () => {
         memo: memo,
         answers: checkboxValues,
       }
-      if (mode === 'past') {
-        if (
-          exif &&
-          exif.latitude !== undefined &&
-          exif.longitude !== undefined &&
-          exif.timestamp
-        ) {
-          payload.latitude = exif.latitude
-          payload.longitude = exif.longitude
-          payload.timestamp = exif.timestamp.toISOString()
-        } else {
-          const position = await getCurrentPositionForPayload()
-          payload.latitude = position.latitude
-          payload.longitude = position.longitude
-        }
-      } else if (mode === 'current') {
+      if (
+        mode === 'past' &&
+        exif?.latitude !== undefined &&
+        exif?.longitude !== undefined &&
+        exif?.timestamp
+      ) {
+        payload.latitude = exif.latitude
+        payload.longitude = exif.longitude
+        payload.timestamp = exif.timestamp.toISOString()
+      } else {
         const position = await getCurrentPositionForPayload()
         payload.latitude = position.latitude
         payload.longitude = position.longitude

--- a/frontend/src/components/map/previewMap.tsx
+++ b/frontend/src/components/map/previewMap.tsx
@@ -1,13 +1,34 @@
 'use client'
 import 'leaflet/dist/leaflet.css'
-import { MapContainer, TileLayer, Marker, ZoomControl } from 'react-leaflet'
+import {
+  MapContainer,
+  TileLayer,
+  Marker,
+  ZoomControl,
+  useMap,
+} from 'react-leaflet'
 import { getIconByType } from '@/components/utils/icon'
 import { HappinessKey } from '@/types/happiness-key'
+import { useEffect } from 'react'
 
 type Props = {
   latitude: number
   longitude: number
   answer: { [key in HappinessKey]: number }
+}
+
+// Component to update map view when coordinates change
+const MapUpdater: React.FC<{ latitude: number; longitude: number }> = ({
+  latitude,
+  longitude,
+}) => {
+  const map = useMap()
+
+  useEffect(() => {
+    map.setView([latitude, longitude], map.getZoom())
+  }, [latitude, longitude, map])
+
+  return null
 }
 
 const PreviewMap: React.FC<Props> = ({ latitude, longitude, answer }) => {
@@ -28,9 +49,10 @@ const PreviewMap: React.FC<Props> = ({ latitude, longitude, answer }) => {
       center={[latitude, longitude]}
       zoom={18}
       zoomControl={false}
-      scrollWheelZoom={false} // スクロールによるズーム無効化
-      dragging={false} // ドラッグ無効化
+      scrollWheelZoom={true} // スクロールによるズーム有効化
+      dragging={true} // ドラッグ有効化
     >
+      <MapUpdater latitude={latitude} longitude={longitude} />
       <ZoomControl position={'bottomleft'} />
       <TileLayer
         attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'


### PR DESCRIPTION
eslint prettierを実行していること
<img width="1055" height="417" alt="image" src="https://github.com/user-attachments/assets/d4719e2c-b067-4242-be4c-615e9bd2d848" />
npm run test:cov
<img width="1060" height="716" alt="image" src="https://github.com/user-attachments/assets/87c94d42-fe41-413c-a10b-e8f93c996667" />
現在の幸福度を入力」のラジオボタンの上に、現在地を表示するミニマップを追加する --- ①
<img width="1917" height="989" alt="image" src="https://github.com/user-attachments/assets/b4c5b3ec-834d-4fbd-b06c-922d58fb1b52" />
幸福度送信時、追加したミニマップの現在地と同じ緯度経度で幸福度が保存されることを確認する
<img width="1915" height="993" alt="image" src="https://github.com/user-attachments/assets/4d9a8993-97e7-4d45-8c08-c4f433b08bba" />

<img width="1911" height="990" alt="image" src="https://github.com/user-attachments/assets/fcd32119-8d46-4ac7-b92c-5b25af4847a9" />

Select image
<img width="1898" height="989" alt="image" src="https://github.com/user-attachments/assets/fd65b5ca-1497-4084-87d7-d125c27a007e" />
After delete image
<img width="1889" height="992" alt="image" src="https://github.com/user-attachments/assets/0693887b-8b09-41a3-b53f-67c1e5795355" />


画像ファイルを選択した際に、画像のgif情報を元にしたミニマップが表示されることを確認する[既存]
<img width="1909" height="987" alt="image" src="https://github.com/user-attachments/assets/ca7df54f-80ee-4cb7-b034-e120de952acd" />
<img width="1918" height="990" alt="image" src="https://github.com/user-attachments/assets/c13a4d43-c1d1-4943-9750-83cc566ba510" />
スマホサイズの画面で動作確認していること（frontend）
<img width="1123" height="955" alt="image" src="https://github.com/user-attachments/assets/de68ce26-6142-4a94-a848-0d49af5df6a5" />
<img width="1126" height="953" alt="image" src="https://github.com/user-attachments/assets/4732f77e-7d96-44ce-920b-a12d1e034ead" />

