### PR TITLE
セキュリティ対応（Critical）　fiware/cygnus-ngsi:3.15.0

### DIFF
--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -213,7 +213,9 @@ services:
         tag: orion
 
   cygnus:
-    image: fiware/cygnus-ngsi:3.15.0
+    build:
+      context: ./fiware/cygnus
+      dockerfile: Dockerfile
     hostname: cygnus
     container_name: cygnus
     environment:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -212,7 +212,9 @@ services:
     restart: always
 
   cygnus:
-    image: fiware/cygnus-ngsi:3.5.0
+    build:
+      context: ./fiware/cygnus
+      dockerfile: Dockerfile
     hostname: cygnus
     container_name: cygnus
     depends_on:
@@ -233,6 +235,12 @@ services:
       - "CYGNUS_API_PORT=5080"
     networks:
       - backend-network
+    healthcheck:
+      test: "curl -f http://cygnus:5080/v1/version"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
     restart: always
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,7 +224,9 @@ services:
     restart: always
 
   cygnus:
-    image: fiware/cygnus-ngsi:3.15.0
+    build:
+      context: ./fiware/cygnus
+      dockerfile: Dockerfile
     hostname: cygnus
     container_name: cygnus
     depends_on:
@@ -245,6 +247,12 @@ services:
       - "CYGNUS_API_PORT=5080"
     networks:
       - backend-network
+    healthcheck:
+      test: "curl -f http://cygnus:5080/v1/version"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
     restart: always
 
 networks:

--- a/fiware/cygnus/.trivyignore
+++ b/fiware/cygnus/.trivyignore
@@ -1,0 +1,7 @@
+# Fiware Cygnus コンテナで zlib について CVE-2023-45853 が検知されるが、Debian 公式で非該当とされているため無視
+# Debian 公式で非該当とされている理由は、以下の通り
+# - https://security-tracker.debian.org/tracker/CVE-2023-45853
+# - CVE-2023-45853 は minizip 内の処理のバッファオーバーフローによる脆弱性
+# - Fiware Cygnus コンテナに含まれる zlib は minizip を含まずにビルドされている
+# - よって、Fiware Cygnus コンテナに含まれる zlib は CVE-2023-45853 に該当しない
+CVE-2023-45853

--- a/fiware/cygnus/Dockerfile
+++ b/fiware/cygnus/Dockerfile
@@ -1,0 +1,50 @@
+# Security updates for fiware/cygnus-ngsi:3.16.0
+
+FROM fiware/cygnus-ngsi:3.16.0
+
+USER root
+
+# Update packages, apply security updates, and cleanup in a single layer
+RUN set -eux; \
+    # Save package list before modifications for cleanup tracking \
+    saved_pkgs_file="/tmp/pkgs.before"; \
+    dpkg-query -W -f='${Package}\n' | sort > "${saved_pkgs_file}"; \
+    \
+    # Update package lists and install essential tools \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg2; \
+    \
+    # Apply security updates for vulnerable packages \
+    apt-get upgrade -y \
+        libsqlite3-0 \
+        libxml2 \
+        zlib1g; \
+    \
+    # Full system upgrade to get latest security patches \
+    apt-get upgrade -y; \
+    apt-get dist-upgrade -y; \
+    \
+    # Clean up package manager \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    # Remove temporary packages that were only needed for updates \
+    cd /; \
+    current_pkgs_file="/tmp/pkgs.after"; \
+    dpkg-query -W -f='${Package}\n' | sort > "${current_pkgs_file}"; \
+    to_remove="$(comm -13 "${saved_pkgs_file}" "${current_pkgs_file}" \
+        | grep -E '^(ca-certificates|curl|gnupg2)$' || true)"; \
+    if [ -n "${to_remove}" ]; then \
+        apt-get update; \
+        apt-get purge -y --auto-remove ${to_remove}; \
+        apt-get clean; \
+        rm -rf /var/lib/apt/lists/*; \
+    fi; \
+    rm -f "${saved_pkgs_file}" "${current_pkgs_file}"; \
+    \
+    # Clean up temporary files and caches \
+    rm -rf /tmp/* /var/tmp/* /root/.cache


### PR DESCRIPTION
*1. docker-compose.ymlを利用し環境を立ち上げ動作確認する*

- 幸福度データ取得・検索
<img width="1915" height="944" alt="image" src="https://github.com/user-attachments/assets/77d03b1f-bb8e-4e36-a583-ddefadb16ce8" />

- 幸福度データ登録
<img width="1862" height="924" alt="image" src="https://github.com/user-attachments/assets/4545bc80-647e-4697-ab33-8da8e932be37" />
<img width="1706" height="150" alt="image" src="https://github.com/user-attachments/assets/a4dd96db-4f34-4959-bcfe-1f6e126ed40b" />


- 幸福度データ削除
<img width="1904" height="564" alt="image" src="https://github.com/user-attachments/assets/8a0f5833-7f36-4c0c-9c1a-76a7bfe77708" />
<img width="1908" height="713" alt="image" src="https://github.com/user-attachments/assets/099e312b-0527-4ec4-9c97-10cb6a5a82f2" />
<img width="1913" height="966" alt="image" src="https://github.com/user-attachments/assets/c45423d3-2cae-4e13-b944-2904523a27c2" />


- 幸福度データインポート
<img width="976" height="228" alt="image" src="https://github.com/user-attachments/assets/f5b339b3-017c-49a6-9817-26f695458b59" />


<img width="1908" height="287" alt="image" src="https://github.com/user-attachments/assets/2f2c78a4-cbee-469c-b597-fd9f125b7434" />

<img width="1703" height="334" alt="image" src="https://github.com/user-attachments/assets/32b0568d-aec2-4c2a-b388-c21149255c8a" />


- 幸福度データエクスポート
<img width="1268" height="356" alt="image" src="https://github.com/user-attachments/assets/33e6fb3c-a0c4-49d0-a3d6-b52e13406512" />

*2. docker-compose-dev.ymlを利用し環境を立ち上げ動作確認する*

- 幸福度データ取得・検索
<img width="1919" height="992" alt="image" src="https://github.com/user-attachments/assets/e771aca4-05a3-4dce-8370-089cd1368e04" />

- 幸福度データ登録
<img width="1914" height="979" alt="image" src="https://github.com/user-attachments/assets/4d0df602-be34-44b3-83cc-fa28401c291d" />


- 幸福度データ削除
<img width="1904" height="564" alt="image" src="https://github.com/user-attachments/assets/8a0f5833-7f36-4c0c-9c1a-76a7bfe77708" />
<img width="1908" height="713" alt="image" src="https://github.com/user-attachments/assets/099e312b-0527-4ec4-9c97-10cb6a5a82f2" />
<img width="1913" height="966" alt="image" src="https://github.com/user-attachments/assets/c45423d3-2cae-4e13-b944-2904523a27c2" />


- 幸福度データインポート
<img width="956" height="245" alt="image" src="https://github.com/user-attachments/assets/462842b5-645f-4c17-ae86-881cbb3c016c" />

<img width="1908" height="287" alt="image" src="https://github.com/user-attachments/assets/2f2c78a4-cbee-469c-b597-fd9f125b7434" />

<img width="1693" height="334" alt="image" src="https://github.com/user-attachments/assets/9137a7ed-9054-4984-a5b2-67f17238b5d4" />

- 幸福度データエクスポート
<img width="1338" height="363" alt="image" src="https://github.com/user-attachments/assets/2286b511-76d3-4d34-9f9f-4813f0c00ad0" />

*3. Trivyを実行し、結果を本Issueにコメントする*
`trivy image fiware/cygnus-ngsi:3.16.0 > fiware_cygnus-ngsi.3.16.0.txt`
[fiware_cygnus-ngsi.3.16.0.txt](https://github.com/user-attachments/files/22207348/fiware_cygnus-ngsi.3.16.0.txt)

```
fiware/cygnus-ngsi:3.16.0 (debian 12.9)
=======================================
Total: 353 (UNKNOWN: 4, LOW: 214, MEDIUM: 84, HIGH: 46, CRITICAL: 5)

Java (jar)
==========
Total: 354 (UNKNOWN: 0, LOW: 22, MEDIUM: 108, HIGH: 154, CRITICAL: 70)
```
*4. Criticalアラートが無くなっているか確認する*
`trivy image fiware/cygnus-ngsi:3.16.0 --severity CRITICAL > fiware_cygnus-ngsi.3.16.0_critical.txt`
[fiware_cygnus-ngsi.3.16.0_critical.txt](https://github.com/user-attachments/files/22207379/fiware_cygnus-ngsi.3.16.0_critical.txt)


```
fiware/cygnus-ngsi:3.16.0 (debian 12.9)
=======================================
Total: 5 (CRITICAL: 5)
```
<img width="1354" height="464" alt="image" src="https://github.com/user-attachments/assets/9c1708b4-551c-4f57-b5d3-dd3213ac4b00" />

```
Java (jar)
==========
Total: 70 (CRITICAL: 70)
```
<img width="1533" height="678" alt="image" src="https://github.com/user-attachments/assets/b13f19e4-088f-4cce-9012-4071eb9a4384" />

*5. Criticalが残っている場合*

**Criticalの原因となっているパッケージのバージョンアップを行う記述をDockerfileに追記する。**
file: fiware/orion/Dockerfile

**Trivyを実行し、結果を本Issueにコメントする**
`trivy image --ignorefile ./fiware/cygnus/.trivyignore oasismap-cygnus:latest --severity CRITICAL --format table > oasismap-cygnus-critical.txt`
[oasismap-cygnus-critical.txt](https://github.com/user-attachments/files/22207529/oasismap-cygnus-critical.txt)

```
oasismap-cygnus:latest (debian 12.12)
=====================================
Total: 1 (CRITICAL: 1)
```
<img width="1073" height="215" alt="image" src="https://github.com/user-attachments/assets/b1330244-e39b-408f-bb86-801a1079bd88" />

```
Java (jar)
==========
Total: 70 (CRITICAL: 70)
```

- **CVE-2025-7458**:
Details:  https://security-tracker.debian.org/tracker/CVE-2025-7458
Status: Currently, there is no patch available for Debian 12
<img width="1507" height="794" alt="image" src="https://github.com/user-attachments/assets/83de50b7-05a9-453b-b15b-3f2310d6164e" />

-  **CVE-2023-45853**
fiware cygnus コンテナで zlib について CVE-2023-45853 が検知されますが、おそらくは誤検知であり、Debian 公式でも非該当とされているため、その検知を無視するために fiware/cygnus/.trivyignore を追加しています。
fiware cygnus のイメージを trivy する際、trivy image --ignorefile ./fiware/cygnus/.trivyignore  oasismap-cygnus:latest --severity CRITICAL --format table みたいに使う感じでお願いします。


