### PR TITLE
セキュリティ対応（High）　quay.io/keycloak/keycloak

### DIFF
--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -149,7 +149,7 @@ services:
         tag: postgres-cli
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.3.1
+    image: quay.io/keycloak/keycloak:26.3.4
     hostname: keycloak
     container_name: keycloak
     ports:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -144,7 +144,7 @@ services:
     entrypoint: ["sh", "/home/postgrescli/scripts/add-column.sh"]
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.3.1
+    image: quay.io/keycloak/keycloak:26.3.4
     hostname: keycloak
     container_name: keycloak
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
     entrypoint: ["sh", "/home/postgrescli/scripts/add-column.sh"]
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.3.1
+    image: quay.io/keycloak/keycloak:26.3.4
     hostname: keycloak
     container_name: keycloak
     ports:


### PR DESCRIPTION
1. docker-compose.yml、docker-compose-azure.yml、docker-compose-dev.ymlのkeycloakが同じイメージを利用していることを確認する
All three use the image: quay.io/keycloak/keycloak:26.3.1

```
  keycloak:
    image: quay.io/keycloak/keycloak:26.3.1
```

2. 上記keycloakイメージ対してTrivyを実行し、CriticlaとHighの結果を本Issueにコメントする
`trivy image quay.io/keycloak/keycloak:26.3.1 --severity CRITICAL,HIGH --format table`
<img width="1529" height="704" alt="image" src="https://github.com/user-attachments/assets/90686835-c38b-43a6-992c-705d2c464a10" />

3. Critical、Highの原因となっているパッケージのバージョンアップを行う記述をDockerfileに追記する。
The latest version of Keycloak is 26.3.4. (https://github.com/keycloak/keycloak/releases)
<img width="1907" height="997" alt="image" src="https://github.com/user-attachments/assets/91397679-947c-4e7a-a218-702ca9e22ce8" />

The current version in use is 26.3.1.
In Keycloak 26.3.1, there are still 6 High vulnerabilities (which I already shared above), while in 26.3.4, there are no longer any High or Critical vulnerabilities.
Proceeding to upgrade Keycloak from 26.3.1 → 26.3.4.

4. docker-compose.ymlを利用し環境を立ち上げ動作確認する

- 一般ユーザーログイン
<img width="1919" height="988" alt="image" src="https://github.com/user-attachments/assets/0abe1d28-3717-4bb9-a10e-f677ff4ca7a5" />

- 管理者ユーザーログイン
<img width="1915" height="996" alt="image" src="https://github.com/user-attachments/assets/a5d77923-c72b-448c-9854-ce8a22add90c" />

- keycloak自動設定
<img width="1187" height="844" alt="image" src="https://github.com/user-attachments/assets/691a99ce-9864-4289-8173-2bae787cbc8f" />

5. docker-compose-dev.ymlを利用し環境を立ち上げ動作確認する

- 一般ユーザーログイン
<img width="1919" height="988" alt="image" src="https://github.com/user-attachments/assets/0abe1d28-3717-4bb9-a10e-f677ff4ca7a5" />

- 管理者ユーザーログイン
<img width="1915" height="996" alt="image" src="https://github.com/user-attachments/assets/a5d77923-c72b-448c-9854-ce8a22add90c" />

- keycloak自動設定
<img width="988" height="835" alt="image" src="https://github.com/user-attachments/assets/52b16e04-148b-4aa9-a1e2-0ced6e3c2e60" />

6. keycloakイメージ対してTrivyを実行し、CriticlaとHighの結果を本Issueにコメントする
`trivy image quay.io/keycloak/keycloak:26.3.4 --severity CRITICAL,HIGH --format table`
<img width="953" height="730" alt="image" src="https://github.com/user-attachments/assets/1abdde35-3363-445e-8915-2b3febd95b0d" />

