### PR TITLE
幸福度追加ボタンを鉛筆アイコンに変更

### DIFF
--- a/frontend/src/app/happiness/all/page.tsx
+++ b/frontend/src/app/happiness/all/page.tsx
@@ -11,7 +11,7 @@ import {
 
 import { useRouter } from 'next/navigation'
 import { signOut, useSession } from 'next-auth/react'
-import { Button, Grid } from '@mui/material'
+import { Grid } from '@mui/material'
 import { PeriodType } from '@/types/period'
 import { MessageType } from '@/types/message-type'
 const Map = dynamic(() => import('@/components/map/map'), { ssr: false })
@@ -252,31 +252,10 @@ const HappinessAll: React.FC = () => {
           fiware={{ servicePath: '', tenant: '' }}
           iconType="heatmap"
           pinData={pinData}
+          showAddHappiness={session?.user?.type === PROFILE_TYPE.GENERAL}
+          onAddHappiness={() => router.push('/happiness/input?referral=all')}
         />
       </Grid>
-      {session?.user?.type === PROFILE_TYPE.GENERAL && (
-        <Grid
-          item
-          xs={12}
-          sx={{
-            position: 'fixed',
-            bottom: '10px',
-            left: '10px',
-            right: '10px',
-            zIndex: 1000,
-          }}
-        >
-          <Button
-            variant="contained"
-            color="primary"
-            size="large"
-            fullWidth
-            onClick={() => router.push('/happiness/input?referral=all')}
-          >
-            幸福度を入力
-          </Button>
-        </Grid>
-      )}
     </Grid>
   )
 }

--- a/frontend/src/app/happiness/me/page.tsx
+++ b/frontend/src/app/happiness/me/page.tsx
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic'
 import { useState, useEffect, useContext, useRef, useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { signOut, useSession } from 'next-auth/react'
-import { Button, Grid } from '@mui/material'
+import { Grid } from '@mui/material'
 import { PeriodType } from '@/types/period'
 import { MessageType } from '@/types/message-type'
 const Map = dynamic(() => import('@/components/map/map'), { ssr: false })
@@ -250,28 +250,9 @@ const HappinessMe: React.FC = () => {
             setInitialEntityId(null)
           }}
           period={period}
+          showAddHappiness={true}
+          onAddHappiness={() => router.push('/happiness/input?referral=me')}
         />
-      </Grid>
-      <Grid
-        item
-        xs={12}
-        sx={{
-          position: 'fixed',
-          bottom: '10px',
-          left: '10px',
-          right: '10px',
-          zIndex: 1000,
-        }}
-      >
-        <Button
-          variant="contained"
-          color="primary"
-          size="large"
-          fullWidth
-          onClick={() => router.push('/happiness/input?referral=me')}
-        >
-          幸福度を入力
-        </Button>
       </Grid>
     </Grid>
   )

--- a/frontend/src/components/map/map.tsx
+++ b/frontend/src/components/map/map.tsx
@@ -29,6 +29,7 @@ import { messageContext } from '@/contexts/message-context'
 import { IconButton } from '@mui/material'
 import NavigationIcon from '@mui/icons-material/Navigation'
 import CurrentPositionIcon from '@mui/icons-material/RadioButtonChecked'
+import EditIcon from '@mui/icons-material/Edit'
 import { renderToString } from 'react-dom/server'
 import { MeModal } from '../happiness/me-modal'
 import { Pin } from '@/types/pin'
@@ -80,6 +81,8 @@ type Props = {
   _highlightTarget?: HighlightTarget
   setHighlightTarget?: React.Dispatch<React.SetStateAction<HighlightTarget>>
   period?: PeriodType
+  showAddHappiness?: boolean
+  onAddHappiness?: () => void
 }
 
 const OnPopupClose = ({ onPopupClose }: { onPopupClose: () => void }) => {
@@ -449,6 +452,8 @@ const Map: React.FC<Props> = ({
   period,
   targetEntity,
   onPopupClose,
+  showAddHappiness,
+  onAddHappiness,
 }) => {
   const { data: session } = useSession()
   const [center, setCenter] = useState<LatLngTuple | null>(null)
@@ -534,7 +539,7 @@ const Map: React.FC<Props> = ({
               border: '1px solid #ccc',
               borderRadius: 100,
               boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
-              marginBottom: '50px',
+              marginBottom: '10px',
             }}
             onClick={() => {
               if (currentPosition) {
@@ -564,6 +569,57 @@ const Map: React.FC<Props> = ({
 
     return null
   }
+
+  const AddHappinessControl = () => {
+    const map = useMap()
+
+    useEffect(() => {
+      if (!showAddHappiness) {
+        return
+      }
+
+      const control: L.Control = new L.Control({ position: 'bottomright' })
+
+      control.onAdd = () => {
+        const div = L.DomUtil.create('div', 'leaflet-control-custom')
+
+        const root = createRoot(div)
+        root.render(
+          <IconButton
+            style={{
+              backgroundColor: '#20B2AA',
+              borderRadius: 100,
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+              marginBottom: '10px',
+            }}
+            onClick={() => {
+              if (onAddHappiness) {
+                onAddHappiness()
+              }
+            }}
+          >
+            <EditIcon
+              style={{
+                color: 'white',
+                fontSize: 45,
+              }}
+            />
+          </IconButton>
+        )
+
+        return div
+      }
+
+      control.addTo(map)
+
+      return () => {
+        control.remove()
+      }
+    }, [map])
+
+    return null
+  }
+
   if (error) {
     console.error('Error: Unable to get current position.', error)
     return null
@@ -582,6 +638,7 @@ const Map: React.FC<Props> = ({
         maxBounds={maxBounds}
         maxBoundsViscosity={maxBoundsViscosity}
       >
+        <AddHappinessControl />
         <MoveToCurrentPositionControl />
         <TileLayer
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'

--- a/frontend/src/components/map/map.tsx
+++ b/frontend/src/components/map/map.tsx
@@ -601,7 +601,7 @@ const Map: React.FC<Props> = ({
             <EditIcon
               style={{
                 color: 'white',
-                fontSize: 45,
+                fontSize: 55,
               }}
             />
           </IconButton>


### PR DESCRIPTION
既存の幸福度追加ボタンを削除する
鉛筆アイコンを追加する
幸福度追加ボタンを鉛筆アイコンに変更

/me
<img width="377" height="811" alt="image" src="https://github.com/user-attachments/assets/59bbc26f-c281-4eb1-9739-dbc1a7d8eb17" />

/all
<img width="373" height="811" alt="image" src="https://github.com/user-attachments/assets/be2a2ad9-d8f2-4616-8a7d-edefefb7ca10" />

/all - admin
<img width="1911" height="839" alt="image" src="https://github.com/user-attachments/assets/78e8e044-cffc-4731-a05e-e95651b95f48" />

鉛筆アイコンをクリックすると、幸福度追加画面が開く
/me
<img width="1887" height="980" alt="image" src="https://github.com/user-attachments/assets/0d165682-dd91-4746-9843-a33aab456411" />

/all
<img width="1910" height="987" alt="image" src="https://github.com/user-attachments/assets/d32fe095-4dba-490e-a2cb-a2864cad02fa" />

eslint prettierを実行していること
frontend
<img width="539" height="136" alt="image" src="https://github.com/user-attachments/assets/a9d5b1d7-6d0a-46dd-9fa6-a1e205f6ee39" />

backend
<img width="424" height="148" alt="image" src="https://github.com/user-attachments/assets/efaffe81-7fbd-4d95-88c7-f7f2b7b2ed40" />

カバレッジの確認をしていること（backend）
<img width="833" height="718" alt="image" src="https://github.com/user-attachments/assets/9749dc09-463d-4eb1-9346-c59c6e6e1489" />

本番用buildを行い、要件を満たすこと確認
<img width="796" height="727" alt="image" src="https://github.com/user-attachments/assets/b5bb4056-f725-449a-a70d-4c65ee2b6d94" />

スマホサイズの画面で動作確認していること（frontend）
/me
<img width="812" height="910" alt="image" src="https://github.com/user-attachments/assets/f0a5ea9a-d096-4d78-8c6a-72d9c94c335d" />

/all
<img width="789" height="901" alt="image" src="https://github.com/user-attachments/assets/15763566-cb96-46ff-aaa7-719b1388b9f1" />

/all - admin
<img width="677" height="919" alt="image" src="https://github.com/user-attachments/assets/8f706466-80d9-4b34-905a-e8b31d853a53" />


