### PR TITLE
利用者の幸福度画面、全体の幸福度画面以外でもヘッダーにフィルターアイコンがある

### DIFF
--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -6,6 +6,7 @@ import FilterAltIcon from '@mui/icons-material/FilterAlt'
 import AppBar from '@mui/material/AppBar'
 import { PROFILE_TYPE } from '@/libs/constants'
 import { useSession } from 'next-auth/react'
+import { usePathname } from 'next/navigation'
 
 interface HeaderProps {
   simple?: boolean
@@ -26,6 +27,11 @@ const Header: React.FC<HeaderProps> = ({
   handleFilterOpen,
 }) => {
   const { data: session } = useSession()
+  const pathname = usePathname()
+
+  // Only show filter button on /happiness/me and /happiness/all routes
+  const shouldShowFilter =
+    pathname === '/happiness/me' || pathname === '/happiness/all'
 
   return (
     <AppBar sx={{ color: '#FFF', backgroundColor: '#459586' }}>
@@ -57,14 +63,16 @@ const Header: React.FC<HeaderProps> = ({
             <Typography noWrap component="div" sx={{ mr: 2 }}>
               <Nickname />
             </Typography>
-            <IconButton
-              color="inherit"
-              aria-label="open filter"
-              edge="end"
-              onClick={handleFilterOpen}
-            >
-              <FilterAltIcon />
-            </IconButton>
+            {shouldShowFilter && (
+              <IconButton
+                color="inherit"
+                aria-label="open filter"
+                edge="end"
+                onClick={handleFilterOpen}
+              >
+                <FilterAltIcon />
+              </IconButton>
+            )}
           </>
         )}
       </Toolbar>


### PR DESCRIPTION
フィルターアイコンが利用者の幸福度画面、全体の幸福度画面のみに表示されるよう修正
/happiness/me
<img width="1902" height="666" alt="image" src="https://github.com/user-attachments/assets/ff88f348-91f1-4c1d-bc9d-8dbded60332a" />

/happiness/all
<img width="1899" height="697" alt="image" src="https://github.com/user-attachments/assets/19348285-5617-4f1b-b74c-0956174aa3a0" />

/happiness/list
<img width="1909" height="691" alt="image" src="https://github.com/user-attachments/assets/b036c60e-0652-402c-b0fd-366b7f969f8d" />

/terms/third-party-license
<img width="1892" height="583" alt="image" src="https://github.com/user-attachments/assets/9f8e8026-abe3-4a42-b6aa-784c187d7da0" />

admin
/happiness/all
<img width="1915" height="653" alt="image" src="https://github.com/user-attachments/assets/2fa70295-c364-4bf2-823c-e3182b8f36c6" />

/admin/import
<img width="1910" height="577" alt="image" src="https://github.com/user-attachments/assets/427630f5-4f63-42b4-80f1-d8c0de4d3847" />

/terms/third-party-license
<img width="1911" height="580" alt="image" src="https://github.com/user-attachments/assets/0f011f7c-93af-465f-9e5b-fa617500dcfc" />

eslint prettierを実行していること
<img width="979" height="353" alt="image" src="https://github.com/user-attachments/assets/f5fcbbd4-d81c-48ab-bd11-08923e8bdc15" />

カバレッジの確認をしていること（backend）
<img width="813" height="661" alt="image" src="https://github.com/user-attachments/assets/7ddaa69a-2b24-4dfd-94e0-5c767b849006" />

本番用buildを行い、要件を満たすこと確認
<img width="902" height="731" alt="image" src="https://github.com/user-attachments/assets/0b2c768f-21ad-4b4b-92a8-6f92435410c3" />

スマホサイズの画面で動作確認していること（frontend）
/happiness/me
<img width="998" height="984" alt="image" src="https://github.com/user-attachments/assets/f630c3de-e12f-4b8e-b57f-6f70e375d522" />

/happiness/all
<img width="877" height="989" alt="image" src="https://github.com/user-attachments/assets/6bc2d406-aec0-43a2-8a17-de17460011ec" />

/happiness/list
<img width="924" height="973" alt="image" src="https://github.com/user-attachments/assets/f2ebb72b-ba6a-4cf3-bf13-d9591ac80359" />

/terms/third-party-license
<img width="995" height="979" alt="image" src="https://github.com/user-attachments/assets/34dd4d85-2747-428e-9949-35635be5a481" />

admin
/happiness/all
<img width="967" height="986" alt="image" src="https://github.com/user-attachments/assets/7edf437f-bb64-47ba-aa66-9fbff3ed1357" />

/admin/import
<img width="933" height="973" alt="image" src="https://github.com/user-attachments/assets/97c659f6-4a18-4b9d-bb8c-95cb9649778c" />

/terms/third-party-license
<img width="1001" height="973" alt="image" src="https://github.com/user-attachments/assets/21968f50-2086-452a-9aea-70c24afa092e" />