### PR TITLE
書き込みボタンが下部のアドレスバーに隠されないように修正

### DIFF
--- a/frontend/src/app/admin/import/layout.tsx
+++ b/frontend/src/app/admin/import/layout.tsx
@@ -16,6 +16,9 @@ export default function HappinessLayout({
           alignItems="center"
           sx={{
             minHeight: '100vh',
+            '@supports (min-height: 100dvh)': {
+              minHeight: '100dvh',
+            },
           }}
         >
           <CircularProgress />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -113,6 +113,10 @@ a {
   height: 50px !important;
 }
 
+.leaflet-control-add-happiness {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
 /* Marker cluster styling for centered numbers and maintaining circular shape */
 .marker-cluster {
   display: flex;

--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -7,6 +7,12 @@
   min-height: 100vh;
 }
 
+@supports (min-height: 100dvh) {
+  .main {
+    min-height: 100dvh;
+  }
+}
+
 .description {
   display: inherit;
   justify-content: inherit;

--- a/frontend/src/components/happiness/happiness-viewer.tsx
+++ b/frontend/src/components/happiness/happiness-viewer.tsx
@@ -45,7 +45,15 @@ const HappinessViewer = ({
         container
         item
         xs={12}
-        sx={{ height: { xs: 'calc(100vh - 56px)', sm: 'calc(100vh - 64px)' } }}
+        sx={{
+          height: { xs: 'calc(100vh - 56px)', sm: 'calc(100vh - 64px)' },
+          '@supports (height: 100dvh)': {
+            height: {
+              xs: 'calc(100dvh - 56px)',
+              sm: 'calc(100dvh - 64px)',
+            },
+          },
+        }}
       >
         <Map
           pinData={pinData}

--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -236,6 +236,9 @@ const ListTable: React.FC<ListTableProps> = ({
       // maxHeightの指定についてはヘッダーの高さ(64px)と親コンポーネントの上下パディング(64px)を差し引く
       sx={{
         maxHeight: 'calc(100vh - 64px - 64px)',
+        '@supports (max-height: 100dvh)': {
+          maxHeight: 'calc(100dvh - 64px - 64px)',
+        },
         border: '1px solid rgba(0, 0, 0, 0.12)',
       }}
     >

--- a/frontend/src/components/map/map.tsx
+++ b/frontend/src/components/map/map.tsx
@@ -561,7 +561,10 @@ const Map: React.FC<Props> = ({
       const control: L.Control = new L.Control({ position: 'bottomright' })
 
       control.onAdd = () => {
-        const div = L.DomUtil.create('div', 'leaflet-control-custom')
+        const div = L.DomUtil.create(
+          'div',
+          'leaflet-control-custom leaflet-control-add-happiness'
+        )
 
         const root = createRoot(div)
         root.render(


### PR DESCRIPTION
CSS で 100dvh（Dynamic Viewport Height）に対応し、.main をはじめとする複数コンポーネントで、ビューポート高さの指定を見直しました。これにより、特に iOS Safari のようにアドレスバーの表示・非表示で高さが変わる環境でも、画面にはみ出さずに表示されるようになります。
あわせて、地図表示を行う happiness-viewer と、幸福度一覧の list-table では、高さや最大高さの計算に 100dvh を使うように変更しました。どちらも「見えている範囲」に合わせた高さになるため、スマートフォンでの表示が安定します。
地図上の幸福度登録ボタン（FAB）用に、新しいクラスを導入し、そのクラスに対してグローバルなスタイルでパディングを指定するようにしました。これにより、ノッチやホームインジケータがある端末でも、ボタンがセーフエリア内に収まるよう余白が確保されます。また、この新しいレイアウト方針に合わせて、グローバルスタイルを調整し、全体の表示が一貫するようにしました。

_修正前_
<img height="500" alt="image" src="https://github.com/user-attachments/assets/886e1746-0751-4039-8b97-132564d53581" />

_修正後_
<img height="500" alt="image" src="https://github.com/user-attachments/assets/2ffb34ee-0e9e-41d7-9b88-d3e9134f206d" />

## その他
セキュリティ警告でCIが落ちている。別PRで要対応