### PR TITLE
現在地表示や書き込みボタンが点滅する現象の解消

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -117,6 +117,14 @@ a {
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
+/* Safari: Leaflet コントロールの点滅・タイル下に隠れる問題のワークアラウンド (#8068) */
+@supports (-webkit-touch-callout: none) {
+  .leaflet-control-container .leaflet-top,
+  .leaflet-control-container .leaflet-bottom {
+    will-change: transform;
+  }
+}
+
 /* Marker cluster styling for centered numbers and maintaining circular shape */
 .marker-cluster {
   display: flex;


### PR DESCRIPTION
## 概要
iPhone（Safari）でマップの幸福度登録 FAB がパン・ズーム時に点滅する事象を、Leaflet の既知の Safari 向け CSS ワークアラウンドの追加で解消しました。

## 背景・原因
事象: 幸福度登録ボタン（AddHappinessControl）が iPhone で一瞬消えたり点滅して見える
想定原因: Safari/WebKit の描画バグ（Leaflet #8068）。パン・ズーム時にコントロールの z-index が正しく扱われず、タイルの下に潜って見える
本プロジェクト: Leaflet 1.9.4 / react-leaflet 5 を使用。.leaflet-control-container 向けの Safari 用ワークアラウンドが未適用だった

## 変更内容
ファイル: frontend/src/app/globals.css
対応: Safari（主に iOS）向けに、.leaflet-control-container の .leaflet-top / .leaflet-bottom に will-change: transform を付与
適用範囲: @supports (-webkit-touch-callout: none) で Safari 系のみに限定し、他ブラウザへの影響を抑制

## その他

セキュリティ警告でCIが落ちている。別PRで要対応