### PR TITLE
地図タイル読み込み失敗時のフォールバック（国土地理院タイル）を追加

### DIFF
--- a/frontend/src/components/map/map.tsx
+++ b/frontend/src/components/map/map.tsx
@@ -629,8 +629,7 @@ const Map: React.FC<Props> = ({
             maxZoom={18}
             minZoom={5}
             eventHandlers={{
-              tileerror: (e: L.TileErrorEvent) =>
-                handleTileError(setUseFallback),
+              tileerror: () => handleTileError(setUseFallback),
             }}
           />
         )}

--- a/frontend/src/components/map/map.tsx
+++ b/frontend/src/components/map/map.tsx
@@ -443,6 +443,7 @@ const Map: React.FC<Props> = ({
   const [error, setError] = useState<Error | null>(null)
   const [selectedPin, setSelectedPin] = useState<Pin | null>(null)
   const noticeMessageContext = useContext(messageContext)
+  const [useFallback, setUseFallback] = useState(false)
 
   useEffect(() => {
     // geolocation が http に対応していないため固定値を設定
@@ -620,12 +621,25 @@ const Map: React.FC<Props> = ({
       >
         <AddHappinessControl />
         <MoveToCurrentPositionControl />
-        <TileLayer
-          attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-          url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
-          maxZoom={18}
-          minZoom={5}
-        />
+        {!useFallback && (
+          <TileLayer
+            attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+            url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+            maxZoom={18}
+            minZoom={5}
+            eventHandlers={{
+              tileerror: () => setUseFallback(true),
+            }}
+          />
+        )}
+        {useFallback && (
+          <TileLayer
+            attribution='&copy; <a href="https://maps.gsi.go.jp/development/ichiran.html">国土地理院</a>'
+            url="https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png"
+            maxZoom={18}
+            minZoom={5}
+          />
+        )}
         <HybridClusterGroup
           pinData={pinData}
           setSelectedPin={setSelectedPin}

--- a/frontend/src/components/map/map.tsx
+++ b/frontend/src/components/map/map.tsx
@@ -42,6 +42,7 @@ import { MeModal } from '../happiness/me-modal'
 import { Pin } from '@/types/pin'
 import { HAPPINESS_KEYS, PROFILE_TYPE } from '@/libs/constants'
 import { MePopup } from './mePopup'
+import { handleTileError } from '@/components/utils/tile-fallback-log'
 import { MessageType } from '@/types/message-type'
 import { HappinessKey } from '@/types/happiness-key'
 
@@ -628,7 +629,8 @@ const Map: React.FC<Props> = ({
             maxZoom={18}
             minZoom={5}
             eventHandlers={{
-              tileerror: () => setUseFallback(true),
+              tileerror: (e: L.TileErrorEvent) =>
+                handleTileError(setUseFallback),
             }}
           />
         )}

--- a/frontend/src/components/map/previewMap.tsx
+++ b/frontend/src/components/map/previewMap.tsx
@@ -8,6 +8,7 @@ import {
   useMap,
 } from 'react-leaflet'
 import { getIconByType } from '@/components/utils/icon'
+import { handleTileError } from '@/components/utils/tile-fallback-log'
 import { HappinessKey } from '@/types/happiness-key'
 import { useEffect, useState } from 'react'
 
@@ -62,7 +63,8 @@ const PreviewMap: React.FC<Props> = ({ latitude, longitude, answer }) => {
           maxZoom={18}
           minZoom={5}
           eventHandlers={{
-            tileerror: () => setUseFallback(true),
+            tileerror: (e: L.TileErrorEvent) =>
+              handleTileError(setUseFallback),
           }}
         />
       )}

--- a/frontend/src/components/map/previewMap.tsx
+++ b/frontend/src/components/map/previewMap.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-leaflet'
 import { getIconByType } from '@/components/utils/icon'
 import { HappinessKey } from '@/types/happiness-key'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 type Props = {
   latitude: number
@@ -32,6 +32,7 @@ const MapUpdater: React.FC<{ latitude: number; longitude: number }> = ({
 }
 
 const PreviewMap: React.FC<Props> = ({ latitude, longitude, answer }) => {
+  const [useFallback, setUseFallback] = useState(false)
   const previewIcon = () => {
     for (const [key, value] of Object.entries(answer) as [
       HappinessKey,
@@ -54,12 +55,25 @@ const PreviewMap: React.FC<Props> = ({ latitude, longitude, answer }) => {
     >
       <MapUpdater latitude={latitude} longitude={longitude} />
       <ZoomControl position={'bottomleft'} />
-      <TileLayer
-        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
-        maxZoom={18}
-        minZoom={5}
-      />
+      {!useFallback && (
+        <TileLayer
+          attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+          maxZoom={18}
+          minZoom={5}
+          eventHandlers={{
+            tileerror: () => setUseFallback(true),
+          }}
+        />
+      )}
+      {useFallback && (
+        <TileLayer
+          attribution='&copy; <a href="https://maps.gsi.go.jp/development/ichiran.html">国土地理院</a>'
+          url="https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png"
+          maxZoom={18}
+          minZoom={5}
+        />
+      )}
       <Marker position={[latitude, longitude]} icon={previewIcon()} />
     </MapContainer>
   )

--- a/frontend/src/components/map/previewMap.tsx
+++ b/frontend/src/components/map/previewMap.tsx
@@ -63,8 +63,7 @@ const PreviewMap: React.FC<Props> = ({ latitude, longitude, answer }) => {
           maxZoom={18}
           minZoom={5}
           eventHandlers={{
-            tileerror: (e: L.TileErrorEvent) =>
-              handleTileError(setUseFallback),
+            tileerror: () => handleTileError(setUseFallback),
           }}
         />
       )}

--- a/frontend/src/components/utils/tile-fallback-log.ts
+++ b/frontend/src/components/utils/tile-fallback-log.ts
@@ -2,7 +2,7 @@
  * エラー情報をログ出力し、フォールバックを有効化する。
  */
 export async function handleTileError(
-  setUseFallback: (v: boolean) => void,
+  setUseFallback: (v: boolean) => void
 ): Promise<void> {
   console.warn('Map tile fallback: OpenStreetMap tile failed')
   setUseFallback(true)

--- a/frontend/src/components/utils/tile-fallback-log.ts
+++ b/frontend/src/components/utils/tile-fallback-log.ts
@@ -1,0 +1,9 @@
+/**
+ * エラー情報をログ出力し、フォールバックを有効化する。
+ */
+export async function handleTileError(
+  setUseFallback: (v: boolean) => void,
+): Promise<void> {
+  console.warn('Map tile fallback: OpenStreetMap tile failed')
+  setUseFallback(true)
+}


### PR DESCRIPTION
### 概要

OpenStreetMap のタイルが読み込めない場合に、自動で国土地理院（GSI）のタイルに切り替えるフォールバック処理を追加しました。ネットワーク障害やタイルサーバーの不調時でも地図が表示され続けるようにします。

フォールバックはクライアント側で動作するため、フォールバック時はコンソールログに出力します。
なお、フォールバック原因はtileerrorからは取得できませんでした。
また、frontendサーバー側へログ出力するには別途対応が必要です。

### 挙動

1. 初期表示は従来どおり OpenStreetMap タイル（tile.openstreetmap.org）を使用
2. タイル読み込みで tileerror が発生したら useFallback を true に更新
3. フォールバック時は国土地理院の標準地図（cyberjapandata.gsi.go.jp/xyz/std）を表示
4. セッション中はフォールバック状態を維持（リロードで OSM に戻る）

### 動作確認

- [x] ドメイン不正
- [x] 存在しないリソース
- [x] ネットワーク障害
- [x] タイムアウト

_ネットワーク障害前_
<img width="398" height="764" alt="image" src="https://github.com/user-attachments/assets/32cd953a-7115-4013-8028-5f9320176533" />

_ネットワーク障害中_
<img width="405" height="765" alt="image" src="https://github.com/user-attachments/assets/c269c31a-9b0f-49d0-8c4a-7bdcac94eda5" />

_ネットワーク障害後_
<img width="399" height="762" alt="image" src="https://github.com/user-attachments/assets/d41e6d12-3298-4d96-bcee-43a6390070c4" />

_ネットワーク復帰後ページ再読み込み_
<img width="401" height="764" alt="image" src="https://github.com/user-attachments/assets/ecc38475-ebac-4439-a099-8f923690430d" />

_タイルサーバから応答がない_
※タイルサーバから404・403・429・500 などの応答が無い場合、ブラウザがタイムアウトと判断するまでマップ表示が欠けたままとなる(数分以上の場合もある)
<img width="478" height="794" alt="image" src="https://github.com/user-attachments/assets/60b418ce-6c8b-4acd-8c70-b871e71fcdf8" />
