### PR TITLE
クライアントエラーのログ収集(プロトタイプ)

### DIFF
--- a/frontend/src/app/admin/import/page.tsx
+++ b/frontend/src/app/admin/import/page.tsx
@@ -15,6 +15,7 @@ import { signOut, useSession } from 'next-auth/react'
 import { messageContext } from '@/contexts/message-context'
 import { useFetchData } from '@/libs/fetch'
 import { useRouter } from 'next/navigation'
+import { pushActionLog, reportError } from '@/libs/client-error-reporting'
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
 
@@ -31,6 +32,7 @@ const Import: React.FC = () => {
   const { upload } = useFetchData()
 
   const fileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    pushActionLog('click', 'importFileSelect')
     const file = event.target.files?.[0]
 
     if (file?.type !== 'text/csv') {
@@ -57,6 +59,8 @@ const Import: React.FC = () => {
       setErrorMessage('ファイルが選択されていません')
       return
     }
+    pushActionLog('click', 'importUpload')
+    pushActionLog('apiCall', 'happiness/import')
     setIsUploading(true)
     setImportError('') // Clear previous import errors
 
@@ -78,6 +82,7 @@ const Import: React.FC = () => {
       )
       router.push('/happiness/all')
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       if (error instanceof Error && error.message === ERROR_TYPE.UNAUTHORIZED) {
         noticeMessageContext.showMessage(

--- a/frontend/src/app/api/client-errors/route.ts
+++ b/frontend/src/app/api/client-errors/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+type ClientErrorBody = {
+  environment?: { userAgent?: string }
+  actionLog?: { entries?: unknown[] }
+  error?: {
+    message?: string
+    stack?: string
+    url?: string
+    occurredAt?: string
+  }
+}
+
+function validate(body: unknown): body is ClientErrorBody {
+  if (body == null || typeof body !== 'object') return false
+  const b = body as Record<string, unknown>
+  const env = b.environment as Record<string, unknown> | undefined
+  const err = b.error as Record<string, unknown> | undefined
+  return (
+    typeof env?.userAgent === 'string' &&
+    typeof err?.message === 'string' &&
+    typeof err?.url === 'string' &&
+    typeof err?.occurredAt === 'string'
+  )
+}
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (!validate(body)) {
+    return NextResponse.json(
+      {
+        error:
+          'Missing required fields: environment.userAgent, error.message, error.url, error.occurredAt',
+      },
+      { status: 400 }
+    )
+  }
+
+  // 1 リクエストあたり 1 行の JSON で stdout に出力
+  console.log(JSON.stringify(body))
+
+  return new NextResponse(null, { status: 204 })
+}

--- a/frontend/src/app/api/client-errors/route.ts
+++ b/frontend/src/app/api/client-errors/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 type ClientErrorBody = {
-  environment?: { userAgent?: string }
+  environment?: { userAgent?: string; geolocationStatus?: string }
   actionLog?: { entries?: unknown[] }
   error?: {
     message?: string
     stack?: string
     url?: string
     occurredAt?: string
+    geolocationErrorCode?: number
   }
 }
 

--- a/frontend/src/app/happiness/input/page.tsx
+++ b/frontend/src/app/happiness/input/page.tsx
@@ -26,6 +26,7 @@ import { ERROR_TYPE } from '@/libs/constants'
 import { useFetchData } from '@/libs/fetch'
 import { HappinessRequestBody } from '@/libs/fetch'
 import { getCurrentPosition } from '@/libs/geolocation'
+import { pushActionLog, reportError } from '@/libs/client-error-reporting'
 import { timestampToDateTime } from '@/libs/date-converter'
 import { HappinessKey } from '@/types/happiness-key'
 import exifr from 'exifr'
@@ -76,6 +77,7 @@ const HappinessInput: React.FC = () => {
         setCurrentPosition(position)
       }
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error getting current position:', error)
     }
   }
@@ -174,6 +176,7 @@ const HappinessInput: React.FC = () => {
       }
       setExif(exif)
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       setErrors((prev) => {
         return [
@@ -189,6 +192,8 @@ const HappinessInput: React.FC = () => {
 
   const submitForm = async () => {
     try {
+      pushActionLog('click', 'inputSubmit')
+      pushActionLog('apiCall', 'happiness/post')
       const answers = createAnswersFromSelected(selectedHappiness)
       let payload: HappinessRequestBody = {
         latitude: 0,
@@ -221,6 +226,7 @@ const HappinessInput: React.FC = () => {
       )
       router.push(`/happiness/${referral}`)
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       if (error instanceof Error && error.message === ERROR_TYPE.UNAUTHORIZED) {
         noticeMessageContext.showMessage(

--- a/frontend/src/app/happiness/list/page.tsx
+++ b/frontend/src/app/happiness/list/page.tsx
@@ -11,6 +11,7 @@ import { HappinessListResponse, Data } from '@/types/happiness-list-response'
 import { useFetchData } from '@/libs/fetch'
 import { useTokenFetchStatus } from '@/hooks/token-fetch-status'
 import { LoadingContext } from '@/contexts/loading-context'
+import { pushActionLog, reportError } from '@/libs/client-error-reporting'
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
 
@@ -27,6 +28,7 @@ const HappinessList: React.FC = () => {
 
   const getData = async () => {
     try {
+      pushActionLog('apiCall', 'happiness/list')
       setIsLoading(true)
       willStop.current = false
       setListData([])
@@ -52,6 +54,7 @@ const HappinessList: React.FC = () => {
         offset += data['count']
       }
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error fetching data:', error)
       if (error instanceof Error && error.message === ERROR_TYPE.UNAUTHORIZED) {
         noticeMessageContext.showMessage(
@@ -74,6 +77,7 @@ const HappinessList: React.FC = () => {
 
   const deleteListData = async (id: string) => {
     try {
+      pushActionLog('apiCall', 'happiness/delete')
       const url = `${backendUrl}/api/happiness/${id}`
       const updatedSession = await update()
 
@@ -86,6 +90,7 @@ const HappinessList: React.FC = () => {
         prevListData.filter((data) => data.id !== id)
       )
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       if (error instanceof Error && error.message === ERROR_TYPE.UNAUTHORIZED) {
         noticeMessageContext.showMessage(

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from 'next/font/google'
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter'
 import MessageArea from '@/components/message'
 import { LoadingProvider } from '@/components/spinner'
+import ClientErrorReporter from '@/components/client-error-reporter'
 
 import './globals.css'
 
@@ -23,6 +24,7 @@ export default function RootLayout({
     <html lang="ja">
       <body className={inter.className}>
         <AppRouterCacheProvider>
+          <ClientErrorReporter />
           <MessageArea>
             <LoadingProvider>{children}</LoadingProvider>
           </MessageArea>

--- a/frontend/src/components/client-error-reporter.tsx
+++ b/frontend/src/components/client-error-reporter.tsx
@@ -1,62 +1,49 @@
 'use client'
 
 import { useEffect } from 'react'
-
-const MAX_STRING_LENGTH = 2000
-
-function truncate(s: string | undefined, max: number): string {
-  if (s == null || s === '') return ''
-  return s.length <= max ? s : s.slice(0, max)
-}
-
-function buildPayload(error: {
-  message: string
-  stack?: string
-  url: string
-}): string {
-  const occurredAt = new Date().toISOString()
-  const payload = {
-    environment: { userAgent: navigator.userAgent },
-    actionLog: { entries: [] as unknown[] },
-    error: {
-      message: truncate(error.message, MAX_STRING_LENGTH),
-      stack: error.stack ? truncate(error.stack, MAX_STRING_LENGTH) : undefined,
-      url: truncate(error.url, MAX_STRING_LENGTH),
-      occurredAt,
-    },
-  }
-  return JSON.stringify(payload)
-}
-
-function sendClientError(payload: string): void {
-  fetch('/api/client-errors', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: payload,
-  }).catch(() => {
-    // fire-and-forget: 送信失敗は無視
-  })
-}
+import { usePathname } from 'next/navigation'
+import {
+  buildReportPayload,
+  sendClientError,
+  isDuplicate,
+  markSent,
+  pushActionLog,
+} from '@/libs/client-error-reporting'
 
 export default function ClientErrorReporter() {
+  const pathname = usePathname()
+
+  // ルート遷移を操作ログに記録
+  useEffect(() => {
+    if (pathname) {
+      pushActionLog('routeChange', pathname)
+    }
+  }, [pathname])
+
   useEffect(() => {
     const handleError = (e: ErrorEvent): void => {
       const url = typeof document !== 'undefined' ? document.location.href : ''
-      const payload = buildPayload({
-        message: e.message || (e.error as Error)?.message || 'Unknown error',
+      const message =
+        e.message || (e.error as Error)?.message || 'Unknown error'
+      if (isDuplicate(message, url)) return
+      const payload = buildReportPayload({
+        message,
         stack: (e.error as Error)?.stack,
         url,
       })
       sendClientError(payload)
+      markSent(message, url)
     }
 
     const handleUnhandledRejection = (event: PromiseRejectionEvent): void => {
       const reason = event.reason
       const url = typeof document !== 'undefined' ? document.location.href : ''
       const message = reason instanceof Error ? reason.message : String(reason)
+      if (isDuplicate(message, url)) return
       const stack = reason instanceof Error ? reason.stack : undefined
-      const payload = buildPayload({ message, stack, url })
+      const payload = buildReportPayload({ message, stack, url })
       sendClientError(payload)
+      markSent(message, url)
     }
 
     window.addEventListener('error', handleError)

--- a/frontend/src/components/client-error-reporter.tsx
+++ b/frontend/src/components/client-error-reporter.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useEffect } from 'react'
+
+const MAX_STRING_LENGTH = 2000
+
+function truncate(s: string | undefined, max: number): string {
+  if (s == null || s === '') return ''
+  return s.length <= max ? s : s.slice(0, max)
+}
+
+function buildPayload(error: {
+  message: string
+  stack?: string
+  url: string
+}): string {
+  const occurredAt = new Date().toISOString()
+  const payload = {
+    environment: { userAgent: navigator.userAgent },
+    actionLog: { entries: [] as unknown[] },
+    error: {
+      message: truncate(error.message, MAX_STRING_LENGTH),
+      stack: error.stack ? truncate(error.stack, MAX_STRING_LENGTH) : undefined,
+      url: truncate(error.url, MAX_STRING_LENGTH),
+      occurredAt,
+    },
+  }
+  return JSON.stringify(payload)
+}
+
+function sendClientError(payload: string): void {
+  fetch('/api/client-errors', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+  }).catch(() => {
+    // fire-and-forget: 送信失敗は無視
+  })
+}
+
+export default function ClientErrorReporter() {
+  useEffect(() => {
+    const handleError = (e: ErrorEvent): void => {
+      const url = typeof document !== 'undefined' ? document.location.href : ''
+      const payload = buildPayload({
+        message: e.message || (e.error as Error)?.message || 'Unknown error',
+        stack: (e.error as Error)?.stack,
+        url,
+      })
+      sendClientError(payload)
+    }
+
+    const handleUnhandledRejection = (event: PromiseRejectionEvent): void => {
+      const reason = event.reason
+      const url = typeof document !== 'undefined' ? document.location.href : ''
+      const message = reason instanceof Error ? reason.message : String(reason)
+      const stack = reason instanceof Error ? reason.stack : undefined
+      const payload = buildPayload({ message, stack, url })
+      sendClientError(payload)
+    }
+
+    window.addEventListener('error', handleError)
+    window.addEventListener('unhandledrejection', handleUnhandledRejection)
+
+    return () => {
+      window.removeEventListener('error', handleError)
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection)
+    }
+  }, [])
+
+  return null
+}

--- a/frontend/src/components/happiness/happiness-viewer.tsx
+++ b/frontend/src/components/happiness/happiness-viewer.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { Grid } from '@mui/material'
 import { useSession } from 'next-auth/react'
 import { PROFILE_TYPE } from '@/libs/constants'
+import { pushActionLog } from '@/libs/client-error-reporting'
 const Map = dynamic(() => import('@/components/map/map'), { ssr: false })
 import { Pin } from '@/types/pin'
 import { Data } from '@/types/happiness-me-response'
@@ -63,9 +64,10 @@ const HappinessViewer = ({
             isMounted.current && router.replace(`/happiness/${type}`)
           }}
           showAddHappiness={session?.user?.type === PROFILE_TYPE.GENERAL}
-          onAddHappiness={() =>
+          onAddHappiness={() => {
+            pushActionLog('click', 'mapAddHappiness')
             router.push(`/happiness/input?referral=${type}`)
-          }
+          }}
         />
       </Grid>
     </Grid>

--- a/frontend/src/components/happiness/list-table.tsx
+++ b/frontend/src/components/happiness/list-table.tsx
@@ -31,6 +31,7 @@ import { Data } from '@/types/happiness-list-response'
 import { timestampToDateTime } from '@/libs/date-converter'
 import DeleteConfirmationDialog from '@/components/happiness/delete-confirmation-dialog'
 import { HappinessKey } from '@/types/happiness-key'
+import { pushActionLog } from '@/libs/client-error-reporting'
 
 type Order = 'asc' | 'desc'
 
@@ -86,6 +87,7 @@ const Row: React.FC<RowProps> = ({ row, openDialog }) => {
   const open = Boolean(anchorElement)
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    pushActionLog('click', 'listRowMenu')
     setAnchorElement(event.currentTarget)
   }
   const handleClose = () => {
@@ -107,7 +109,10 @@ const Row: React.FC<RowProps> = ({ row, openDialog }) => {
           <IconButton
             aria-label={isCollapseOpen ? 'collapse row' : 'expand row'}
             size="small"
-            onClick={() => setIsCollapseOpen(!isCollapseOpen)}
+            onClick={() => {
+              pushActionLog('click', 'listRowExpand')
+              setIsCollapseOpen(!isCollapseOpen)
+            }}
             sx={{ px: '0px' }}
           >
             {isCollapseOpen ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
@@ -163,6 +168,7 @@ const Row: React.FC<RowProps> = ({ row, openDialog }) => {
       <Menu anchorEl={anchorElement} open={open} onClose={handleClose}>
         <MenuItem
           onClick={() => {
+            pushActionLog('click', 'listShowOnMap')
             const params = new URLSearchParams()
             params.set('entityId', row.id)
             params.set('timestamp', row.timestamp)
@@ -177,7 +183,12 @@ const Row: React.FC<RowProps> = ({ row, openDialog }) => {
             secondary="選択した幸福度を地図に表示します"
           />
         </MenuItem>
-        <MenuItem onClick={() => openDialog(row)}>
+        <MenuItem
+          onClick={() => {
+            pushActionLog('click', 'listDelete')
+            openDialog(row)
+          }}
+        >
           <ListItemIcon>
             <DeleteForever sx={{ color: 'black' }} />
           </ListItemIcon>
@@ -198,6 +209,7 @@ const ListTable: React.FC<ListTableProps> = ({
   const [orderBy, setOrderBy] = useState<HappinessKey | null>(null)
 
   const handleSort = (property: HappinessKey) => {
+    pushActionLog('click', 'listSort')
     if (orderBy === property) {
       if (order === undefined) {
         setOrder('desc')
@@ -225,6 +237,7 @@ const ListTable: React.FC<ListTableProps> = ({
 
   const deleteRowData = () => {
     if (selectedData) {
+      pushActionLog('click', 'deleteConfirmDelete')
       deleteListData(selectedData.id)
       setSelectedData(null)
     }
@@ -307,7 +320,10 @@ const ListTable: React.FC<ListTableProps> = ({
       </Table>
       <DeleteConfirmationDialog
         data={selectedData}
-        onClose={() => setSelectedData(null)}
+        onClose={() => {
+          pushActionLog('click', 'deleteConfirmCancel')
+          setSelectedData(null)
+        }}
         deleteRowData={deleteRowData}
       />
     </TableContainer>

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -7,6 +7,7 @@ import AppBar from '@mui/material/AppBar'
 import { PROFILE_TYPE } from '@/libs/constants'
 import { useSession } from 'next-auth/react'
 import { usePathname } from 'next/navigation'
+import { pushActionLog } from '@/libs/client-error-reporting'
 
 interface HeaderProps {
   simple?: boolean
@@ -41,7 +42,10 @@ const Header: React.FC<HeaderProps> = ({
             color="inherit"
             aria-label="open drawer"
             edge="start"
-            onClick={handleDrawerOpen}
+            onClick={() => {
+              pushActionLog('click', 'headerMenu')
+              handleDrawerOpen?.()
+            }}
             sx={{ mr: 2 }}
           >
             <MenuIcon />
@@ -68,7 +72,10 @@ const Header: React.FC<HeaderProps> = ({
                 color="inherit"
                 aria-label="open filter"
                 edge="end"
-                onClick={handleFilterOpen}
+                onClick={() => {
+                  pushActionLog('click', 'headerFilter')
+                  handleFilterOpen?.()
+                }}
               >
                 <FilterAltIcon />
               </IconButton>

--- a/frontend/src/components/map/map.tsx
+++ b/frontend/src/components/map/map.tsx
@@ -32,6 +32,12 @@ import 'leaflet.markercluster/dist/MarkerCluster.css'
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
 import { getIconByType } from '../utils/icon'
 import { messageContext } from '@/contexts/message-context'
+import {
+  setGeolocationStatus,
+  reportPositionError,
+  positionErrorCodeToStatus,
+  pushActionLog,
+} from '@/libs/client-error-reporting'
 
 import { IconButton } from '@mui/material'
 import NavigationIcon from '@mui/icons-material/Navigation'
@@ -257,6 +263,7 @@ const HybridClusterGroup = ({
   const createMarkerClickHandler = useCallback(
     (pin: Pin) => {
       return () => {
+        pushActionLog('click', 'mapPinClick')
         // Set popup
         setPopupPin(pin)
         setPopupPosition([pin.latitude, pin.longitude])
@@ -363,12 +370,19 @@ const HybridClusterGroup = ({
     // Update initial cluster display
     updateClusters()
 
-    // Listen to zoom events to update clusters
-    map.on('zoomend', updateClusters)
+    // Listen to zoom events to update clusters and log mapInteraction
+    const onZoomEnd = () => {
+      updateClusters()
+      pushActionLog('mapInteraction', 'mapZoom')
+    }
+    const onMoveEnd = () => pushActionLog('mapInteraction', 'mapPan')
+    map.on('zoomend', onZoomEnd)
+    map.on('moveend', onMoveEnd)
 
     return () => {
       // Remove event listener
-      map.off('zoomend', updateClusters)
+      map.off('zoomend', onZoomEnd)
+      map.off('moveend', onMoveEnd)
 
       // Remove all cluster groups
       Object.values(happinessClustersRef.current).forEach((clusterGroup) => {
@@ -397,6 +411,7 @@ const HybridClusterGroup = ({
     if (!map) return
 
     const handleMapClick = () => {
+      pushActionLog('click', 'mapPopupClose')
       setPopupPin(null)
       setPopupPosition(null)
     }
@@ -417,6 +432,7 @@ const HybridClusterGroup = ({
           offset={[0, -20]}
           eventHandlers={{
             remove: () => {
+              pushActionLog('click', 'mapPopupClose')
               setPopupPin(null)
               setPopupPosition(null)
             },
@@ -455,6 +471,7 @@ const Map: React.FC<Props> = ({
     }
     const watchId = navigator.geolocation.watchPosition(
       (position) => {
+        setGeolocationStatus('available')
         const newPosition: LatLngTuple = [
           position.coords.latitude,
           position.coords.longitude,
@@ -468,7 +485,9 @@ const Map: React.FC<Props> = ({
         setCurrentPosition(newPosition)
         setError(null)
       },
-      (e) => {
+      (e: GeolocationPositionError) => {
+        setGeolocationStatus(positionErrorCodeToStatus(e.code))
+        reportPositionError(e.code)
         console.error(e)
         setError(e instanceof Error ? e : new Error(e.message))
         if (e.code === e.PERMISSION_DENIED) {

--- a/frontend/src/components/search-drawer.tsx
+++ b/frontend/src/components/search-drawer.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material'
 import ChevronDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import { DateTimeProps } from '@/types/search-context'
+import { pushActionLog } from '@/libs/client-error-reporting'
 import {
   DateTimeTextbox,
   useDateTimeProps,
@@ -31,16 +32,22 @@ const SearchDrawer: React.FC<SearchDrawerProps> = ({
   const { startProps, endProps } = useDateTimeProps()
 
   const handleSearch = async () => {
+    pushActionLog('click', 'search')
     onSearch(startProps, endProps)
 
     onClose()
   }
 
+  const handleClose = () => {
+    pushActionLog('click', 'searchDrawerClose')
+    onClose()
+  }
+
   return (
-    <Drawer anchor={'bottom'} open={isOpen} onClose={onClose}>
+    <Drawer anchor={'bottom'} open={isOpen} onClose={handleClose}>
       <Box sx={{ p: 2 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-          <IconButton onClick={onClose} sx={{ mr: 1 }}>
+          <IconButton onClick={handleClose} sx={{ mr: 1 }}>
             <ChevronDownIcon />
           </IconButton>
           <Typography variant="h6" component="div">

--- a/frontend/src/components/sidebar/admin-sidebar.tsx
+++ b/frontend/src/components/sidebar/admin-sidebar.tsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react'
 import { useRouter } from 'next/navigation'
+import { pushActionLog, reportError } from '@/libs/client-error-reporting'
 import Box from '@mui/material/Box'
 import Drawer from '@mui/material/Drawer'
 import List from '@mui/material/List'
@@ -30,11 +31,14 @@ const AdminSidebar: React.FC<AdminSidebarProps> = (props) => {
 
   const downloadCsv = async () => {
     try {
+      pushActionLog('click', 'sidebarExport')
+      pushActionLog('apiCall', 'happiness/export')
       const url = backendUrl + '/api/happiness/export'
       // アクセストークンを再取得
       const updatedSession = await update()
       await download(url, updatedSession?.user?.accessToken!)
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       if (error instanceof Error && error.message === ERROR_TYPE.UNAUTHORIZED) {
         noticeMessageContext.showMessage(
@@ -64,7 +68,12 @@ const AdminSidebar: React.FC<AdminSidebarProps> = (props) => {
         <Divider />
         <List>
           <ListItem key="happiness-all" disablePadding>
-            <ListItemButton onClick={() => router.push('/happiness/all')}>
+            <ListItemButton
+              onClick={() => {
+                pushActionLog('click', 'sidebarNav')
+                router.push('/happiness/all')
+              }}
+            >
               <ListItemText primary="全体の幸福度" />
             </ListItemButton>
           </ListItem>
@@ -74,19 +83,32 @@ const AdminSidebar: React.FC<AdminSidebarProps> = (props) => {
             </ListItemButton>
           </ListItem>
           <ListItem key="happiness-import" disablePadding>
-            <ListItemButton onClick={() => router.push('/admin/import')}>
+            <ListItemButton
+              onClick={() => {
+                pushActionLog('click', 'sidebarNav')
+                router.push('/admin/import')
+              }}
+            >
               <ListItemText primary="データのインポート" />
             </ListItemButton>
           </ListItem>
           <ListItem key="license" disablePadding>
             <ListItemButton
-              onClick={() => router.push('/terms/third-party-license')}
+              onClick={() => {
+                pushActionLog('click', 'sidebarNav')
+                router.push('/terms/third-party-license')
+              }}
             >
               <ListItemText primary="サードパーティライセンス" />
             </ListItemButton>
           </ListItem>
           <ListItem key="logout" disablePadding>
-            <ListItemButton onClick={() => signOut({ callbackUrl: '/login' })}>
+            <ListItemButton
+              onClick={() => {
+                pushActionLog('click', 'sidebarSignOut')
+                signOut({ callbackUrl: '/login' })
+              }}
+            >
               <ListItemText primary="ログアウト" />
             </ListItemButton>
           </ListItem>

--- a/frontend/src/components/sidebar/general-sidebar.tsx
+++ b/frontend/src/components/sidebar/general-sidebar.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/navigation'
+import { pushActionLog } from '@/libs/client-error-reporting'
 import Box from '@mui/material/Box'
 import Drawer from '@mui/material/Drawer'
 import List from '@mui/material/List'
@@ -30,29 +31,52 @@ const GeneralSidebar: React.FC<GeneralSidebarProps> = (props) => {
         <Divider />
         <List>
           <ListItem key="happiness" disablePadding>
-            <ListItemButton onClick={() => router.push('/happiness/me')}>
+            <ListItemButton
+              onClick={() => {
+                pushActionLog('click', 'sidebarNav')
+                router.push('/happiness/me')
+              }}
+            >
               <ListItemText primary="利用者の幸福度" />
             </ListItemButton>
           </ListItem>
           <ListItem key="happiness-all" disablePadding>
-            <ListItemButton onClick={() => router.push('/happiness/all')}>
+            <ListItemButton
+              onClick={() => {
+                pushActionLog('click', 'sidebarNav')
+                router.push('/happiness/all')
+              }}
+            >
               <ListItemText primary="全体の幸福度" />
             </ListItemButton>
           </ListItem>
           <ListItem key="happiness-list" disablePadding>
-            <ListItemButton onClick={() => router.push('/happiness/list')}>
+            <ListItemButton
+              onClick={() => {
+                pushActionLog('click', 'sidebarNav')
+                router.push('/happiness/list')
+              }}
+            >
               <ListItemText primary="一覧表示" />
             </ListItemButton>
           </ListItem>
           <ListItem key="license" disablePadding>
             <ListItemButton
-              onClick={() => router.push('/terms/third-party-license')}
+              onClick={() => {
+                pushActionLog('click', 'sidebarNav')
+                router.push('/terms/third-party-license')
+              }}
             >
               <ListItemText primary="サードパーティライセンス" />
             </ListItemButton>
           </ListItem>
           <ListItem key="logout" disablePadding>
-            <ListItemButton onClick={() => signOut({ callbackUrl: '/login' })}>
+            <ListItemButton
+              onClick={() => {
+                pushActionLog('click', 'sidebarSignOut')
+                signOut({ callbackUrl: '/login' })
+              }}
+            >
               <ListItemText primary="ログアウト" />
             </ListItemButton>
           </ListItem>

--- a/frontend/src/components/utils/tile-fallback-log.ts
+++ b/frontend/src/components/utils/tile-fallback-log.ts
@@ -1,9 +1,12 @@
+import { reportError } from '@/libs/client-error-reporting'
+
 /**
  * エラー情報をログ出力し、フォールバックを有効化する。
  */
 export async function handleTileError(
   setUseFallback: (v: boolean) => void
 ): Promise<void> {
+  reportError(new Error('Map tile load failed: OpenStreetMap tile failed'))
   console.warn('Map tile fallback: OpenStreetMap tile failed')
   setUseFallback(true)
 }

--- a/frontend/src/hooks/use-happiness-data.ts
+++ b/frontend/src/hooks/use-happiness-data.ts
@@ -17,6 +17,7 @@ import { Data } from '@/types/happiness-me-response'
 import { DateTime as OasismapDateTime } from '@/types/datetime'
 import { useSearchContext } from '@/contexts/search-context'
 import { SearchParams, DateTimeProps } from '@/types/search-context'
+import { pushActionLog, reportError } from '@/libs/client-error-reporting'
 
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
 
@@ -53,6 +54,10 @@ export const useHappinessData = ({ type }: UseHappinessDataProps) => {
     async (opts?: SearchParams) => {
       if (isLoading) return
       try {
+        pushActionLog(
+          'apiCall',
+          type === 'me' ? 'happiness/me' : 'happiness/all'
+        )
         setIsLoading(true)
         setContextIsLoading(true)
         willStop.current = false
@@ -103,6 +108,9 @@ export const useHappinessData = ({ type }: UseHappinessDataProps) => {
             const newPins = GetPin(data['data'])
             setPinData((prevPinData: Pin[]) => [...prevPinData, ...newPins])
           } catch (error) {
+            reportError(
+              error instanceof Error ? error : new Error(String(error))
+            )
             console.error('Error in GetPin or setPinData:', error)
           }
 
@@ -136,6 +144,7 @@ export const useHappinessData = ({ type }: UseHappinessDataProps) => {
           )
         }
       } catch (error) {
+        reportError(error instanceof Error ? error : new Error(String(error)))
         console.error('Error fetching data:', error)
         if (
           error instanceof Error &&

--- a/frontend/src/libs/client-error-reporting.ts
+++ b/frontend/src/libs/client-error-reporting.ts
@@ -1,0 +1,224 @@
+/**
+ * クライアントエラー報告の操作ログ・環境状態・重複防止を管理するモジュール。
+ */
+
+const ACTION_LOG_MAX = 20
+const MAX_STRING_LENGTH = 2000
+const DEDUP_MS = 5000
+
+export type ActionLogType =
+  | 'routeChange'
+  | 'apiCall'
+  | 'click'
+  | 'mapInteraction'
+
+export type ActionLogEntry = {
+  type: ActionLogType
+  label: string
+  timestamp: string
+}
+
+/**
+ * 報告時点での位置情報（GPS）の状態。
+ * PositionError.code は 1/2/3 の3種のみだが、ここでは「状態全体」を表すため6値。
+ * - permission_denied / position_unavailable / timeout: PositionError の3種に対応
+ * - available: getCurrentPosition / watchPosition の取得成功後
+ * - not_supported: navigator.geolocation が無い、または非セキュアコンテキスト（http:）
+ * - not_attempted: まだ取得を試していない、またはエラー・成功どちらにもなっていない初期状態
+ */
+export type GeolocationStatus =
+  | 'available'
+  | 'permission_denied'
+  | 'position_unavailable'
+  | 'timeout'
+  | 'not_supported'
+  | 'not_attempted'
+
+// モジュールスコープのリングバッファ
+const actionLogEntries: ActionLogEntry[] = []
+
+// 位置情報状態（getCurrentPosition / watchPosition の結果で更新）
+let geolocationStatus: GeolocationStatus = 'not_attempted'
+
+// 重複送信防止用
+let lastSentKey: string | null = null
+let lastSentAt = 0
+
+function truncate(s: string | undefined, max: number): string {
+  if (s == null || s === '') return ''
+  return s.length <= max ? s : s.slice(0, max)
+}
+
+/**
+ * 操作ログに 1 件追加（リングバッファ、最大 ACTION_LOG_MAX 件）
+ */
+export function pushActionLog(type: ActionLogType, label: string): void {
+  const entry: ActionLogEntry = {
+    type,
+    label,
+    timestamp: new Date().toISOString(),
+  }
+  actionLogEntries.push(entry)
+  if (actionLogEntries.length > ACTION_LOG_MAX) {
+    actionLogEntries.shift()
+  }
+}
+
+/**
+ * 現在の操作ログのスナップショットを返す（送信用）
+ */
+export function getActionLogSnapshot(): ActionLogEntry[] {
+  return [...actionLogEntries]
+}
+
+/**
+ * 報告時点の位置情報状態を返す
+ */
+export function getGeolocationStatus(): GeolocationStatus {
+  if (typeof navigator === 'undefined' || !navigator.geolocation) {
+    return 'not_supported'
+  }
+  return geolocationStatus
+}
+
+/**
+ * 位置情報状態を設定（getCurrentPosition / watchPosition のコールバックから呼ぶ）
+ */
+export function setGeolocationStatus(status: GeolocationStatus): void {
+  geolocationStatus = status
+}
+
+/**
+ * PositionError.code を detailed-design の geolocationStatus に変換
+ */
+export function positionErrorCodeToStatus(code: number): GeolocationStatus {
+  switch (code) {
+    case 1:
+      return 'permission_denied'
+    case 2:
+      return 'position_unavailable'
+    case 3:
+      return 'timeout'
+    default:
+      return 'position_unavailable'
+  }
+}
+
+/**
+ * 同一エラーの短時間連続送信を抑制するかどうか
+ */
+export function isDuplicate(message: string, url: string): boolean {
+  const key = `${truncate(message, 200)}|${truncate(url, 500)}`
+  if (lastSentKey === key && Date.now() - lastSentAt < DEDUP_MS) {
+    return true
+  }
+  return false
+}
+
+/**
+ * 送信済みとして記録（重複防止用）
+ */
+export function markSent(message: string, url: string): void {
+  const key = `${truncate(message, 200)}|${truncate(url, 500)}`
+  lastSentKey = key
+  lastSentAt = Date.now()
+}
+
+/**
+ * 報告ペイロードを組み立て（environment.actionLog / geolocationStatus / error を含む）
+ */
+export function buildReportPayload(error: {
+  message: string
+  stack?: string
+  url: string
+  geolocationErrorCode?: number
+}): string {
+  const occurredAt = new Date().toISOString()
+  const env: { userAgent: string; geolocationStatus?: string } = {
+    userAgent: navigator.userAgent,
+  }
+  const status = getGeolocationStatus()
+  if (status !== 'not_attempted') {
+    env.geolocationStatus = status
+  }
+
+  const errorPayload: {
+    message: string
+    stack?: string
+    url: string
+    occurredAt: string
+    geolocationErrorCode?: number
+  } = {
+    message: truncate(error.message, MAX_STRING_LENGTH),
+    url: truncate(error.url, MAX_STRING_LENGTH),
+    occurredAt,
+  }
+  if (error.stack) {
+    errorPayload.stack = truncate(error.stack, MAX_STRING_LENGTH)
+  }
+  if (error.geolocationErrorCode !== undefined) {
+    errorPayload.geolocationErrorCode = error.geolocationErrorCode
+  }
+
+  const payload = {
+    environment: env,
+    actionLog: { entries: getActionLogSnapshot() },
+    error: errorPayload,
+  }
+  return JSON.stringify(payload)
+}
+
+/**
+ * 任意のエラーを /api/client-errors に送信する。
+ * try/catch 内から呼ぶことで、キャッチしたエラーも報告できる。
+ * 重複防止（同一 message+url の短時間再送抑制）がかかる。
+ */
+export function reportError(
+  error: Error | { message: string },
+  options?: { geolocationErrorCode?: number }
+): void {
+  const message = error instanceof Error ? error.message : String(error.message)
+  const stack = error instanceof Error ? error.stack : undefined
+  const url = typeof document !== 'undefined' ? document.location.href : ''
+  if (isDuplicate(message, url)) return
+  const payload = buildReportPayload({
+    message,
+    stack,
+    url,
+    geolocationErrorCode: options?.geolocationErrorCode,
+  })
+  sendClientError(payload)
+  markSent(message, url)
+}
+
+/**
+ * 位置情報エラー（PositionError）を報告送信する。
+ * getCurrentPosition / watchPosition のエラーコールバックから呼ぶ。
+ */
+export function reportPositionError(code: number): void {
+  const status = positionErrorCodeToStatus(code)
+  setGeolocationStatus(status)
+  const url = typeof document !== 'undefined' ? document.location.href : ''
+  const message = `Geolocation error: ${status} (code ${code})`
+  if (isDuplicate(message, url)) return
+  const payload = buildReportPayload({
+    message,
+    url,
+    geolocationErrorCode: code,
+  })
+  sendClientError(payload)
+  markSent(message, url)
+}
+
+/**
+ * POST 送信（fire-and-forget）
+ */
+export function sendClientError(payload: string): void {
+  fetch('/api/client-errors', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+  }).catch(() => {
+    // fire-and-forget: 送信失敗は無視
+  })
+}

--- a/frontend/src/libs/fetch.ts
+++ b/frontend/src/libs/fetch.ts
@@ -1,6 +1,7 @@
 import { useContext } from 'react'
 import { ERROR_TYPE } from './constants'
 import { LoadingContext } from '@/contexts/loading-context'
+import { reportError } from '@/libs/client-error-reporting'
 
 interface HappinessParams {
   limit: number
@@ -68,6 +69,7 @@ export const useFetchData = () => {
 
       return jsonData
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       throw error
     } finally {
@@ -104,6 +106,7 @@ export const useFetchData = () => {
 
       return jsonData
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       throw error
     } finally {
@@ -135,6 +138,7 @@ export const useFetchData = () => {
       }
       return jsonData
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       throw error
     } finally {
@@ -166,6 +170,7 @@ export const useFetchData = () => {
 
       return response
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       throw error
     } finally {
@@ -204,6 +209,7 @@ export const useFetchData = () => {
         window.URL.revokeObjectURL(objectUrl)
       }, 250)
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       throw error
     } finally {
@@ -228,6 +234,7 @@ export const useFetchData = () => {
         throw Error(jsonData?.message)
       }
     } catch (error) {
+      reportError(error instanceof Error ? error : new Error(String(error)))
       console.error('Error:', error)
       throw error
     } finally {

--- a/frontend/src/libs/geolocation.ts
+++ b/frontend/src/libs/geolocation.ts
@@ -1,3 +1,9 @@
+import {
+  setGeolocationStatus,
+  reportPositionError,
+  positionErrorCodeToStatus,
+} from './client-error-reporting'
+
 export const getCurrentPosition = async () => {
   // 環境変数の取得に失敗した場合は日本経緯度原点を設定
   const defaultLatitude =
@@ -7,6 +13,14 @@ export const getCurrentPosition = async () => {
 
   // geolocation が http に対応していないため固定値を返却
   if (location.protocol === 'http:') {
+    setGeolocationStatus('not_supported')
+    return {
+      latitude: defaultLatitude,
+      longitude: defaultLongitude,
+    }
+  }
+  if (!navigator.geolocation) {
+    setGeolocationStatus('not_supported')
     return {
       latitude: defaultLatitude,
       longitude: defaultLongitude,
@@ -15,9 +29,18 @@ export const getCurrentPosition = async () => {
   try {
     const position: GeolocationPosition = await new Promise(
       (resolve, reject) => {
-        navigator.geolocation.getCurrentPosition(resolve, reject, {
-          enableHighAccuracy: true,
-        })
+        navigator.geolocation.getCurrentPosition(
+          (pos) => {
+            setGeolocationStatus('available')
+            resolve(pos)
+          },
+          (err: GeolocationPositionError) => {
+            setGeolocationStatus(positionErrorCodeToStatus(err.code))
+            reportPositionError(err.code)
+            reject(err)
+          },
+          { enableHighAccuracy: true }
+        )
       }
     )
     return {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,6 +4,7 @@ type Permission = 'pubilc' | 'general' | 'admin'
 
 const paths: Record<string, Permission[]> = {
   '/': ['pubilc'],
+  '/api/client-errors': ['general', 'admin'],
   '/login': ['pubilc'],
   '/terms/use': ['pubilc'],
   '/terms/privacy-policy': ['pubilc'],


### PR DESCRIPTION
## 概要
ブラウザ上でエラーが発生した時にコンソールログとfrontendコンテナにログ出力するように対応
ログ収集対象者として、ログインしているユーザと管理者を想定
`/client-error`としてPOSTし、成功時は`204`を返す

## ペイロードの概要
以下の3項目を出力
- `actionLog`: 操作ログ（ヘッダーやラベルのクリック、ルーティングを過去20件分記録）
  - ユーザ操作が関連する個所にどのような操作をしたのかを設定した、url（の一部）や実行時の日時を保存
  - 現状 `apiCall`、`click`、`mapInteraction（地図関連の操作）`、`routeChange（画面遷移）` を`actionLog.entries[x].type`に設定
- `enviroment`: 使用デバイスやブラウザを表示
  - https://developer.mozilla.org/ja/docs/Web/API/Navigator/userAgent を使用
- `error`: 発生したエラーの詳細
  - message、発生日時、URL、スタック時のログを表示

## 実行例
<img width="1715" height="919" alt="image" src="https://github.com/user-attachments/assets/efe2d9c9-3c49-4fc7-b7f6-45d5158db44a" />
<img width="943" height="383" alt="image" src="https://github.com/user-attachments/assets/7516faa2-a873-4da7-ae1a-8029bd4fd823" />

`actionLog.entries`のリスト内容は左のデータ（先頭）が古く、右（最後尾）が最新の情報です
直後に記載の`error`に至るまでのユーザー操作を表しており、原因を調査する補助情報として想定しています

## 確認したエラーパターン
位置情報をOFFにして以下の動作でエラーが出ることを確認
- ログイン後初期表示	一般ユーザ・管理者
- 幸福度一覧表示	一般ユーザ
- 幸福度登録（通常、画像添付）	一般ユーザ
- 幸福度削除	一般ユーザ
- 幸福度インポート	管理者
- 幸福度エクスポート	管理者
- 地図タイル読み込み失敗時
- アクセストークン期限切れ後に操作

## try-catch外で発生したエラーの検知について
### ブラウザで `error / unhandledrejection` として通知するものはキャッチ可能
`frontend/src/components/client-error-reporter.tsx` 
>    window.addEventListener('error', handleError)
    window.addEventListener('unhandledrejection', handleUnhandledRejection)

https://github.com/c-3lab/oasismap/pull/393/changes#diff-8a4eff86f584ef8bf08f0dad00a85554fe9e7bfe6e35528fe1d8fbaa1cca86b7R49-R50

### 上記の handleErrorとhandleUnhandledRejection でキャッチできていることを確認
各呼び出しでログ出力を設定し、開発者ツールのコンソールで動作確認
- handleError
<img width="350" alt="image" src="https://github.com/user-attachments/assets/d8620ca8-9089-436c-8884-847f4c5cc186" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/e125f39c-00cd-4972-a4c6-2f91a17f44cc" />
<img width="1050" height="212" alt="image" src="https://github.com/user-attachments/assets/9bbb0f61-4cf1-4bbe-8124-55ac9852be30" />


- handleUnhandledRejection
<img width="350" alt="image" src="https://github.com/user-attachments/assets/7a030754-cf5a-45f5-ab5b-26ff4c0e2c59" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/195129a3-69a8-4e4c-ba4d-76d1ac879d17" />
<img width="1046" height="279" alt="image" src="https://github.com/user-attachments/assets/296c4427-455d-471e-ad35-aaa35b604809" />



