### PR TITLE
Next.jsビルド時のESLint無効化設定を削除

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,10 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ['starseeker-frontend'],
-  eslint: {
-    // ESLintの警告を無視する設定
-    ignoreDuringBuilds: true,
-  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## 概要

https://github.com/c-3lab/oasismap/pull/376 で暫定的に無効化したESLintを有効化し、Build時に実行されるESLintが出す警告を解消する。

## 変更内容
- next.config.js の ESLint 設定を変更
  - eslint.ignoreDuringBuilds: true を削除

## 動作確認
<img width="1066" height="772" alt="image" src="https://github.com/user-attachments/assets/65678c34-e935-4e99-b691-e0303eb9c822" />


