### PR TITLE
参加同意書等の文言を修正

### DIFF
--- a/backend/src/happiness/happiness-input.service.spec.ts
+++ b/backend/src/happiness/happiness-input.service.spec.ts
@@ -86,7 +86,7 @@ describe('HappinessInputService', () => {
           zoom: 10,
         },
         headers: {
-          'User-Agent': 'OasisMap (TIS_WB@ml.tis.co.jp)',
+          'User-Agent': 'OasisMap (TISI_WB@ml.tisi.jp)',
         },
       });
       expect(spyPost).toHaveBeenCalledWith(
@@ -158,7 +158,7 @@ describe('HappinessInputService', () => {
           zoom: 10,
         },
         headers: {
-          'User-Agent': 'OasisMap (TIS_WB@ml.tis.co.jp)',
+          'User-Agent': 'OasisMap (TISI_WB@ml.tisi.jp)',
         },
       });
       expect(spyPost).toHaveBeenCalledWith(

--- a/backend/src/happiness/happiness-input.service.ts
+++ b/backend/src/happiness/happiness-input.service.ts
@@ -122,7 +122,7 @@ export class HappinessInputService {
           zoom: 10,
         },
         headers: {
-          'User-Agent': 'OasisMap (TIS_WB@ml.tis.co.jp)',
+          'User-Agent': 'OasisMap (TISI_WB@ml.tisi.jp)',
         },
       })
       .then((response) => {

--- a/frontend/src/app/terms/use/page.tsx
+++ b/frontend/src/app/terms/use/page.tsx
@@ -41,8 +41,6 @@ const TermsOfService: React.FC = () => {
           </Typography>
           <Typography variant="body1" style={{ wordWrap: 'break-word' }}>
             ・インターネット接続可能なスマートフォンをお持ちの方
-            <br />
-            ・Googleアカウントをお持ちでログイン操作ができる方
           </Typography>
           <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 2 }}>
             ３．提供サービス
@@ -56,7 +54,7 @@ const TermsOfService: React.FC = () => {
             ４．個人情報の取扱い
           </Typography>
           <Typography variant="body1">
-            本実証実験において収集される情報は、サービス提供事業者であるTIS株式会社および{TERMS_MUNICIPALITY_NAME}が厳重に管理し、プライバシーマークおよび情報セキュリティマネジメントシステムの要求事項に準拠して取り扱います。
+            本実証実験において収集される情報は、サービス提供事業者であるTISI株式会社および{TERMS_MUNICIPALITY_NAME}が厳重に管理し、プライバシーマークおよび情報セキュリティマネジメントシステムの要求事項に準拠して取り扱います。
             また、提供された個人情報は、実証実験の目的以外には使用されません。
           </Typography>
           <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mt: 2 }}>
@@ -65,7 +63,7 @@ const TermsOfService: React.FC = () => {
           <Typography variant="body1">
             ・本サービスを利用した営業活動
             <br />
-            ・TIS株式会社および{TERMS_MUNICIPALITY_NAME}による本サービスの運営を妨害する行為
+            ・TISI株式会社および{TERMS_MUNICIPALITY_NAME}による本サービスの運営を妨害する行為
             <br />
             ・他のユーザ、第三者の権利を侵害する行為
           </Typography>


### PR DESCRIPTION
## 概要

Googleログインの廃止や社名の変更に伴い、参加同意書等の一部ファイルの文言を修正する。

## 変更内容
- Googleログインを廃止したため、[参加条件]の「・Googleアカウントをお持ちでログイン操作ができる方」を削除
- [個人情報の取扱い]のTIS株式会社の部分をTISI株式会社へ変更
- その他ファイルのメールアドレスをTIS_WB@ml.tis.co.jpからTISI_WB@ml.tisi.jpに変更


## 動作確認
<img width="532" height="68" alt="スクリーンショット 2026-08-14 112546" src="https://github.com/user-attachments/assets/29fb36ef-3201-4ac0-8234-7de733d8a68e" />
<img width="631" height="56" alt="スクリーンショット 2026-08-14 112600" src="https://github.com/user-attachments/assets/ec4dc852-c7fe-4faf-b17e-fb5322e5a29a" />


